### PR TITLE
2333: Disable editing of checkbox in PR Progress Section

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CSRCommand.java
@@ -37,8 +37,8 @@ import static org.openjdk.skara.bots.pr.CheckRun.CSR_PROCESS_LINK;
 
 public class CSRCommand implements CommandHandler {
 
-    private static final Pattern CSR_PROGRESS_PATTERN = Pattern.compile("- \\[[ x]?\\] Change requires CSR request \\[(.*?)\\]\\((.*?)\\) to be approved");
-    private static final Pattern RESOLVED_CSR_PROGRESS_PATTERN = Pattern.compile("- \\[x\\] Change requires CSR request \\[(.*?)\\]\\((.*?)\\) to be approved");
+    private static final Pattern CSR_PROGRESS_PATTERN = Pattern.compile("- \\\\?\\[[ x]?\\\\?\\] Change requires CSR request \\[(.*?)\\]\\((.*?)\\) to be approved");
+    private static final Pattern RESOLVED_CSR_PROGRESS_PATTERN = Pattern.compile("- \\\\?\\[x\\\\?\\] Change requires CSR request \\[(.*?)\\]\\((.*?)\\) to be approved");
 
     private static void showHelp(PrintWriter writer) {
         writer.println("usage: `/csr [needed|unneeded]`, requires that the issue the pull request refers to links to an approved [CSR](" + CSR_PROCESS_LINK + ") request.");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -667,7 +667,7 @@ class CheckRun {
         var checks = reviewNeeded ? visitor.getChecks() : visitor.getReadyForReviewChecks();
         checks.putAll(additionalProgresses);
         return checks.entrySet().stream()
-                .map(entry -> "- [" + (entry.getValue() ? "x" : " ") + "] " + entry.getKey())
+                .map(entry -> "- \\[" + (entry.getValue() ? "x" : " ") + "\\] " + entry.getKey())
                 .collect(Collectors.joining("\n"));
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRBotTests.java
@@ -98,7 +98,7 @@ class CSRBotTests {
             TestBotRunner.runPeriodicItems(csrIssueBot);
             // The bot should have removed the CSR label
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertTrue(pr.store().body().contains("- [x] Change requires CSR request"));
+            assertTrue(pr.store().body().contains("- \\[x\\] Change requires CSR request"));
         }
     }
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CSRCommandTests.java
@@ -85,7 +85,7 @@ class CSRCommandTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // No longer require CSR
             prAsReviewer.addComment("/csr unneeded");
@@ -108,7 +108,7 @@ class CSRCommandTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -164,7 +164,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "This pull request already associated with these approved CSRs:");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [x] " + generateCSRProgressMessage(csr)));
+            assertTrue(pr.store().body().contains("- \\[x\\] " + generateCSRProgressMessage(csr)));
         }
     }
 
@@ -212,7 +212,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "To refer this pull request to an issue in JBS");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -278,7 +278,7 @@ class CSRCommandTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Stating that a CSR is not needed should not work
             pr.addComment("/csr unneeded");
@@ -287,7 +287,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "can determine that a CSR is not needed.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Stating that a CSR is not needed should not work
             prAsAnother.addComment("/csr unneeded");
@@ -296,7 +296,7 @@ class CSRCommandTests {
             assertLastCommentContains(prAsAnother, "are allowed to use the `csr` command.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -390,7 +390,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "to be able to link it to a [CSR](" + CSR_PROCESS_LINK + ") request. To refer this pull request to an issue in JBS");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -438,7 +438,7 @@ class CSRCommandTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Require a CSR again
             prAsReviewer.addComment("/csr");
@@ -449,7 +449,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "request is already required for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -508,7 +508,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
             assertLastCommentContains(pr, "<!-- csr: 'needed' -->");
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(csr)));
+            assertTrue(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(csr)));
 
             // Indicate the PR doesn't require CSR, but it doesn't work.
             prAsReviewer.addComment("/csr unneeded");
@@ -519,7 +519,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "and then use the command `/csr unneeded` again.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(csr)));
+            assertTrue(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(csr)));
 
             // withdraw the csr
             csr.setState(Issue.State.CLOSED);
@@ -594,7 +594,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
             assertLastCommentContains(pr, "<!-- csr: 'needed' -->");
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(csr)));
+            assertTrue(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(csr)));
 
             // Indicate the PR doesn't require CSR, but it doesn't work.
             prAsReviewer.addComment("/csr unneeded");
@@ -605,7 +605,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "and then use the command `/csr unneeded` again.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(csr)));
+            assertTrue(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(csr)));
 
             // withdraw the csr
             csr.setState(Issue.State.CLOSED);
@@ -621,7 +621,7 @@ class CSRCommandTests {
                     "is not needed for this pull request.");
             assertFalse(pr.store().labelNames().contains("csr"));
             // The PR body shouldn't contain the progress about CSR request
-            assertFalse(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(csr)));
+            assertFalse(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(csr)));
         }
     }
 
@@ -663,7 +663,7 @@ class CSRCommandTests {
                                           "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -729,7 +729,7 @@ class CSRCommandTests {
             assertFalse(prAsAuthor.labelNames().contains("ready"));
 
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
         }
     }
 
@@ -850,7 +850,7 @@ class CSRCommandTests {
             // "csr" label should be added automatically because the main issue has a resolved CSR
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(3 ,pr.store().comments().size());
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertLastCommentContains(pr, "this backport may also need a CSR");
             TestBotRunner.runPeriodicItems(prBot);
             assertEquals(3 ,pr.store().comments().size());
@@ -858,7 +858,7 @@ class CSRCommandTests {
             // Run prBot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "@user1 an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
 
@@ -891,7 +891,7 @@ class CSRCommandTests {
             // Run prBot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion (No fixVersion in .jcheck/conf) to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "@user1 an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
 
@@ -918,7 +918,7 @@ class CSRCommandTests {
             // Run prBot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "@user1 an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
 
@@ -937,13 +937,13 @@ class CSRCommandTests {
             // Run prBot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [x] " + generateCSRProgressMessage(csr)));
+            assertTrue(pr.store().body().contains("- \\[x\\] " + generateCSRProgressMessage(csr)));
             assertFalse(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "This pull request already associated with these approved CSRs:");
             // Use `/csr unneeded`.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [x] " + generateCSRProgressMessage(csr)));
+            assertTrue(pr.store().body().contains("- \\[x\\] " + generateCSRProgressMessage(csr)));
             assertFalse(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "The CSR requirement cannot be removed as CSR issues already exist.");
             assertLastCommentContains(pr, "and then use the command `/csr unneeded` again");
@@ -961,7 +961,7 @@ class CSRCommandTests {
             // Run prBot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "@user1 an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
 
@@ -984,13 +984,13 @@ class CSRCommandTests {
             // Run prBot. Request a CSR.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(backportCsr)));
+            assertTrue(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(backportCsr)));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(backportCsr)));
+            assertTrue(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(backportCsr)));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "The CSR requirement cannot be removed as CSR issues already exist.");
             assertLastCommentContains(pr, "and then use the command `/csr unneeded` again.");
@@ -1013,7 +1013,7 @@ class CSRCommandTests {
             // Run prBot.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(backportCsr)));
+            assertTrue(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(backportCsr)));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "an approved [CSR](" + CSR_PROCESS_LINK + ") request is already required for this pull request.");
             assertLastCommentContains(pr, "<!-- csr: 'needed' -->");
@@ -1023,7 +1023,7 @@ class CSRCommandTests {
             // Use `/csr unneeded` to revert the change.
             pr.addComment("/csr unneeded");
             TestBotRunner.runPeriodicItems(prBot);
-            assertFalse(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(backportCsr)));
+            assertFalse(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(backportCsr)));
             assertFalse(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "determined that a [CSR](" + CSR_PROCESS_LINK + ") request " +
                     "is not needed for this pull request.");
@@ -1031,7 +1031,7 @@ class CSRCommandTests {
             // re-run prBot.
             pr.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 11 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 11 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             assertLastCommentContains(pr, "has indicated that a " +
                     "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
@@ -1104,7 +1104,7 @@ class CSRCommandTests {
                     "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             var issue2 = issues.createIssue("This is an issue2", List.of(), Map.of());
             issue2.setProperty("issuetype", JSON.of("Bug"));
@@ -1120,7 +1120,7 @@ class CSRCommandTests {
             pr.addComment("/issue TEST-2");
             TestBotRunner.runPeriodicItems(prBot);
             assertTrue(pr.store().labelNames().contains("csr"));
-            assertTrue(pr.store().body().contains("- [ ] " + generateCSRProgressMessage(csr2)));
+            assertTrue(pr.store().body().contains("- \\[ \\] " + generateCSRProgressMessage(csr2)));
 
             // Try /csr unneeded, it should fail
             prAsReviewer.addComment("/csr unneeded");
@@ -1146,7 +1146,7 @@ class CSRCommandTests {
                     "is needed for this pull request.");
             assertTrue(pr.store().labelNames().contains("csr"));
             // The PR body should contain the progress about CSR request
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
 
             // Create a csr for main issue
             var csr1 = issues.createIssue("This is a CSR1", List.of(), Map.of("resolution",
@@ -1214,8 +1214,8 @@ class CSRCommandTests {
             prAsReviewer.addComment("/csr");
             TestBotRunner.runPeriodicItems(prBot);
             assertFalse(pr.store().labelNames().contains("csr"));
-            assertTrue(pr.store().body().contains("- [x] " + generateCSRProgressMessage(csr)));
-            assertTrue(pr.store().body().contains("- [x] " + generateCSRProgressMessage(csr2)));
+            assertTrue(pr.store().body().contains("- \\[x\\] " + generateCSRProgressMessage(csr)));
+            assertTrue(pr.store().body().contains("- \\[x\\] " + generateCSRProgressMessage(csr2)));
         }
     }
 
@@ -1275,7 +1275,7 @@ class CSRCommandTests {
             assertLastCommentContains(pr, "has indicated that a " +
                     "[compatibility and specification](" + CSR_PROCESS_LINK + ") (CSR) request " +
                     "is needed for this pull request.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 0.1 to be approved (needs to be created)"));
             assertFalse(pr.store().body().contains(generateCSRProgressMessage(csr)));
             assertFalse(pr.store().body().contains(generateCSRProgressMessage(csr2)));
         }
@@ -1361,7 +1361,7 @@ class CSRCommandTests {
             PullRequestUtils.postPullRequestLinkComment(issue, pr);
 
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires CSR request [TEST-4](http://localhost/project/testTEST-4) to be approved"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires CSR request [TEST-4](http://localhost/project/testTEST-4) to be approved"));
             assertTrue(pr.store().labelNames().contains("csr"));
             // The bot shouldn't post backport csr comment because there is a backport csr
             assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("this backport may also need a CSR")));
@@ -1370,7 +1370,7 @@ class CSRCommandTests {
             backportCsr.setProperty("fixVersions", JSON.array().add("19"));
             TestBotRunner.runPeriodicItems(csrIssueBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertTrue(pr.store().body().contains("- [ ] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a CSR request matching fixVersion 17 to be approved (needs to be created)"));
             assertTrue(pr.store().labelNames().contains("csr"));
             // The bot shouldn't post backport csr comment because csr label is still there
             assertTrue(pr.store().comments().stream().noneMatch(comment -> comment.body().contains("this backport may also need a CSR")));

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/JEPCommandTests.java
@@ -92,7 +92,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -111,7 +111,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -130,7 +130,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -149,7 +149,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -168,7 +168,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
-            assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[x\\] Change requires a JEP request to be targeted"));
 
             // Not require jep by using `uneeded`
             prAsReviewer.addComment("/jep uneeded");
@@ -187,7 +187,7 @@ public class JEPCommandTests {
             assertFalse(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
             assertLastCommentContains(pr, "has already been targeted.");
-            assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[x\\] Change requires a JEP request to be targeted"));
 
             // Not require jep
             prAsReviewer.addComment("/jep unneeded");
@@ -206,7 +206,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
         }
     }
 
@@ -269,7 +269,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Require jep by a reviewer
             prAsReviewer.addComment("/jep TEST-2");
@@ -279,7 +279,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
             assertLastCommentContains(pr, "has been targeted.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Not require jep by a committer
             prAsCommitter.addComment("/jep unneeded");
@@ -289,7 +289,7 @@ public class JEPCommandTests {
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "Only the pull request author and [Reviewers]" +
                     "(https://openjdk.org/bylaws#reviewer) are allowed to use the `jep` command.");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Not require jep by a reviewer
             prAsReviewer.addComment("/jep unneeded");
@@ -469,7 +469,7 @@ public class JEPCommandTests {
                 assertEquals(i * 2 + 1, pr.comments().size());
                 assertLastCommentContains(pr, "This pull request will not be integrated until the [JEP-");
                 assertLastCommentContains(pr, "has been targeted.");
-                assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+                assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
             }
 
             // Test targeted/integrated/completed/closedWithDelivered JEPs
@@ -480,7 +480,7 @@ public class JEPCommandTests {
                 assertEquals(i * 2 + 1, pr.comments().size());
                 assertLastCommentContains(pr, "The JEP for this pull request, [JEP-");
                 assertLastCommentContains(pr, "has already been targeted.");
-                assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
+                assertTrue(pr.store().body().contains("- \\[x\\] Change requires a JEP request to be targeted"));
             }
         }
     }
@@ -522,7 +522,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(disableJepBot);
             assertLastCommentContains(pr, "This repository has not been configured to use the `jep` command.");
             assertFalse(pr.store().labelNames().contains(JEP_LABEL));
-            assertFalse(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertFalse(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Test the PR bot with jep enable
             var enableJepBot = PullRequestBot.newBuilder()
@@ -536,7 +536,7 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(enableJepBot);
             assertLastCommentContains(pr, "pull request will not be integrated until the");
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
         }
     }
 
@@ -581,14 +581,14 @@ public class JEPCommandTests {
             TestBotRunner.runPeriodicItems(issueBot);
             assertTrue(pr.store().labelNames().contains(JEP_LABEL));
             assertLastCommentContains(pr, "pull request will not be integrated until the");
-            assertTrue(pr.store().body().contains("- [ ] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change requires a JEP request to be targeted"));
 
             // Make the jep issue Targeted
             jepIssue.setProperty("status", JSON.object().put("name", "Targeted"));
             jepIssue.setProperty(JEP_NUMBER, JSON.of("123"));
             TestBotRunner.runPeriodicItems(issueBot);
             assertFalse(pr.store().labelNames().contains(JEP_LABEL));
-            assertTrue(pr.store().body().contains("- [x] Change requires a JEP request to be targeted"));
+            assertTrue(pr.store().body().contains("- \\[x\\] Change requires a JEP request to be targeted"));
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -173,7 +173,7 @@ class MergeTests {
 
             // pr should not be ready, because review needed for merge pull requests
             assertFalse(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("- [ ] Change must be properly reviewed"));
+            assertTrue(pr.store().body().contains("- \\[ \\] Change must be properly reviewed"));
 
             // Approve it as another user
             var approvalPr = integrator.pullRequest(pr.id());
@@ -181,7 +181,7 @@ class MergeTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             assertTrue(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("- [x] Change must be properly reviewed"));
+            assertTrue(pr.store().body().contains("- \\[x\\] Change must be properly reviewed"));
 
             // Push it
             pr.addComment("/integrate");
@@ -270,14 +270,14 @@ class MergeTests {
             TestBotRunner.runPeriodicItems(mergeBot);
             assertTrue(pr.store().labelNames().contains("clean"));
             assertFalse(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("[ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))"));
+            assertTrue(pr.store().body().contains("\\[ \\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))"));
 
             // Approve it
             var reviewerPr = integrator.pullRequest(pr.id());
             reviewerPr.addReview(Review.Verdict.APPROVED, "LGTM");
             TestBotRunner.runPeriodicItems(mergeBot);
             assertTrue(pr.store().labelNames().contains("ready"));
-            assertTrue(pr.store().body().contains("[x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))"));
+            assertTrue(pr.store().body().contains("\\[x\\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))"));
 
             // Push it
             pr.addComment("/integrate");


### PR DESCRIPTION
This patch escapes the brackets of checkbox in PR Progress Section, so user can't edit them in UI

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2333](https://bugs.openjdk.org/browse/SKARA-2333): Disable editing of checkbox in PR Progress Section (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1775/head:pull/1775` \
`$ git checkout pull/1775`

Update a local copy of the PR: \
`$ git checkout pull/1775` \
`$ git pull https://git.openjdk.org/skara.git pull/1775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1775`

View PR using the GUI difftool: \
`$ git pr show -t 1775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1775.diff">https://git.openjdk.org/skara/pull/1775.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1775#issuecomment-4511841176)
</details>
