### PR TITLE
2731: Remove references to JVMCI

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -62,7 +62,6 @@
             "src/jdk.jshell/",
             "test/langtools/TEST.ROOT",
             "test/langtools/TEST.groups",
-            "test/langtools/ProblemList-graal.txt",
             "test/langtools/ProblemList.txt",
             "test/langtools/req.flg",
             "test/langtools/lib/combo/TEST.properties",
@@ -245,7 +244,6 @@
             "test/hotspot/jtreg/vmTestbase/vm/share/"
         ],
         "hotspot-compiler": [
-            "src/hotspot/.mx.jvmci/",
             "src/hotspot/cpu/",
             "src/hotspot/share/adlc/",
             "src/hotspot/share/aot/",
@@ -258,12 +256,10 @@
             "src/hotspot/share/gc/g1/c1",
             "src/hotspot/share/gc/g1/c2/",
             "src/hotspot/share/gc/shared/.*barrierset",
-            "src/hotspot/share/jvmci/",
             "src/hotspot/share/libadt/",
             "src/hotspot/share/opto/",
             "src/hotspot/share/runtime/(deoptimization|frame|icache|registermap|sharedruntime|stub|sweeper|vframe)",
             "src/jdk.aot/",
-            "src/jdk.internal.vm.ci/",
             "src/jdk.internal.vm.compiler.management/",
             "src/jdk.internal.vm.compiler/",
             "src/utils/IdealGraphVisualizer/",
@@ -320,7 +316,6 @@
         "hotspot-jfr": [
             "make/modules/jdk.jfr/",
             "src/hotspot/share/jfr/",
-            "src/jdk.internal.vm.ci/share/classes/jdk.vm.ci.hotspot/src/jdk/vm/ci/hotspot/JFR.java",
             "src/jdk.jfr/",
             "src/jdk.management.jfr/",
             "test/hotspot/gtest/jfr/",


### PR DESCRIPTION
After the removal of JVMCI we should clean up references to it and Graal.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2731](https://bugs.openjdk.org/browse/SKARA-2731): Remove references to JVMCI (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - no project role)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - no project role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1776/head:pull/1776` \
`$ git checkout pull/1776`

Update a local copy of the PR: \
`$ git checkout pull/1776` \
`$ git pull https://git.openjdk.org/skara.git pull/1776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1776`

View PR using the GUI difftool: \
`$ git pr show -t 1776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1776.diff">https://git.openjdk.org/skara/pull/1776.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1776#issuecomment-4552091220)
</details>
