### PR TITLE
2733: Remove two directories from security label in config/mailinglist/rules/jdk.json

### DIFF
--- a/config/mailinglist/rules/jdk.json
+++ b/config/mailinglist/rules/jdk.json
@@ -538,8 +538,6 @@
             "src/java.base/share/classes/javax/crypto/",
             "src/java.base/share/classes/javax/net/ssl/",
             "src/java.base/share/classes/javax/security/",
-            "src/java.base/share/classes/jdk/internal/access/",
-            "src/java.base/share/classes/jdk/internal/event/",
             "src/java.base/share/classes/sun/security/",
             "src/java.base/share/conf/security/",
             "src/java.base/share/data/cacerts/",


### PR DESCRIPTION
Suggest removing watches on `jdk/internal/event` and `jdk/internal/internal` from the `security` label. Most changes in these directories are not seclibs-related. Historically, the changes in these two directories that were seclibs-related also touched other seclibs-related files, which would have already triggered the label. Keeping these two directories in the rule only creates noise.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2733](https://bugs.openjdk.org/browse/SKARA-2733): Remove two directories from security label in config/mailinglist/rules/jdk.json (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - no project role)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - no project role)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - no project role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1777/head:pull/1777` \
`$ git checkout pull/1777`

Update a local copy of the PR: \
`$ git checkout pull/1777` \
`$ git pull https://git.openjdk.org/skara.git pull/1777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1777`

View PR using the GUI difftool: \
`$ git pr show -t 1777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1777.diff">https://git.openjdk.org/skara/pull/1777.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1777#issuecomment-4594038624)
</details>
