### PR TITLE
2734: Add EmailSender support for mailing list delivery

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@ package org.openjdk.skara.bots.mlbridge;
 import java.net.URI;
 import org.openjdk.skara.bot.*;
 import org.openjdk.skara.email.EmailAddress;
+import org.openjdk.skara.email.EmailSender;
+import org.openjdk.skara.email.EmailSenderFactory;
 import org.openjdk.skara.mailinglist.MailingListReader;
 import org.openjdk.skara.mailinglist.MailingListServer;
 import org.openjdk.skara.network.URIBuilder;
@@ -83,7 +85,11 @@ public class MailingListBridgeBotFactory implements BotFactory {
         if (specific.get("server").contains("type")) {
             archiveType = specific.get("server").get("type").asString();
         }
-        var listSmtp = specific.get("server").get("smtp").asString();
+        if (!specific.get("server").contains("sender")) {
+            throw new RuntimeException("server.sender must be configured");
+        }
+        var senderConfig = specific.get("server").get("sender").asObject();
+        var emailSender = EmailSenderFactory.create(senderConfig);
         var interval = specific.get("server").contains("interval") ?
                 Duration.parse(specific.get("server").get("interval").asString()) : Duration.ofSeconds(1);
 
@@ -108,7 +114,7 @@ public class MailingListBridgeBotFactory implements BotFactory {
         if (specific.get("server").contains("etag")) {
             useEtag = specific.get("server").get("etag").asBoolean();
         }
-        MailingListServer mailmanServer = createMailmanServer(archiveType, listArchive, listSmtp, interval, useEtag);
+        MailingListServer mailmanServer = createMailmanServer(archiveType, listArchive, emailSender, interval, useEtag);
 
         var mailingListReaderMap = new HashMap<Set<EmailAddress>, MailingListReader>();
 
@@ -191,13 +197,15 @@ public class MailingListBridgeBotFactory implements BotFactory {
         return ret;
     }
 
-    private static MailingListServer createMailmanServer(String archiveType, URI listArchive, String listSmtp,
-            Duration sendInterval, boolean useEtag) {
+    private static MailingListServer createMailmanServer(String archiveType, URI listArchive, EmailSender emailSender,
+                                                         Duration sendInterval, boolean useEtag) {
         MailingListServer mailmanServer;
         if (archiveType == null || archiveType.equals("mailman2")) {
-            mailmanServer = MailingListServerFactory.createMailman2Server(listArchive, listSmtp, sendInterval, useEtag);
+            mailmanServer = MailingListServerFactory.createMailman2Server(listArchive, emailSender,
+                                                                          sendInterval, useEtag);
         } else if (archiveType.equals("mailman3")) {
-            mailmanServer = MailingListServerFactory.createMailman3Server(listArchive, listSmtp, sendInterval);
+            mailmanServer = MailingListServerFactory.createMailman3Server(listArchive, emailSender,
+                                                                          sendInterval);
         } else {
             throw new RuntimeException("Invalid server archive type: " + archiveType);
         }

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListArchiveReaderBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,8 +68,7 @@ class MailingListArchiveReaderBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -141,8 +140,7 @@ class MailingListArchiveReaderBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -217,8 +215,7 @@ class MailingListArchiveReaderBotTests {
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
             // The mailing list as well
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -297,8 +294,7 @@ class MailingListArchiveReaderBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                     .from(from)
                     .repo(author)

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactoryTest.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,10 @@ class MailingListBridgeBotFactoryTest {
                       },
                       "server": {
                         "archive": "https://mail.test.org/test/",
-                        "smtp": "0.0.0.0",
+                        "sender": {
+                          "type": "smtp",
+                          "server": "0.0.0.0"
+                        },
                         "interval": "PT5S",
                         "etag": true,
                       },

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,7 +120,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -314,8 +314,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -408,8 +407,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -483,8 +481,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -563,8 +560,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -641,8 +637,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -731,8 +726,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -786,8 +780,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -894,8 +887,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -993,8 +985,7 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1122,8 +1113,7 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1195,8 +1185,7 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1260,8 +1249,7 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1326,8 +1314,7 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1390,8 +1377,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1447,8 +1433,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1524,8 +1509,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1615,8 +1599,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -1726,8 +1709,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var sender = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(sender)
                                             .repo(author)
@@ -1813,8 +1795,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var sender = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                     .from(sender)
                     .repo(author)
@@ -1906,8 +1887,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var sender = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(sender)
                                             .repo(author)
@@ -1987,8 +1967,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2074,8 +2053,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2147,8 +2125,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2219,8 +2196,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2301,8 +2277,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2393,8 +2368,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2461,8 +2435,7 @@ class MailingListBridgeBotTests {
                                            .addReviewer(reviewer.forge().currentUser().id())
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2522,8 +2495,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBotBuilder = MailingListBridgeBot.newBuilder()
                                                    .from(from)
                                                    .repo(bot)
@@ -2588,8 +2560,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBotBuilder = MailingListBridgeBot.newBuilder()
                                                    .from(from)
                                                    .repo(bot)
@@ -2656,8 +2627,7 @@ class MailingListBridgeBotTests {
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
             var cooldown = Duration.ofMillis(500);
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBotBuilder = MailingListBridgeBot.newBuilder()
                                                    .from(from)
                                                    .repo(bot)
@@ -2747,8 +2717,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2805,8 +2774,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2863,8 +2831,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -2924,8 +2891,7 @@ class MailingListBridgeBotTests {
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
             var cooldown = Duration.ofMillis(500);
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBotBuilder = MailingListBridgeBot.newBuilder()
                                                    .from(from)
                                                    .repo(bot)
@@ -3017,8 +2983,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -3096,8 +3061,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -3296,8 +3260,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -3383,8 +3346,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -3457,8 +3419,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                                             .from(from)
                                             .repo(author)
@@ -3534,8 +3495,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                     .from(from)
                     .repo(author)
@@ -3711,8 +3671,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                     .from(from)
                     .repo(author)
@@ -3856,8 +3815,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                     .from(from)
                     .repo(author)
@@ -3943,8 +3901,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                     .from(from)
                     .repo(author)
@@ -4036,8 +3993,7 @@ class MailingListBridgeBotTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addAuthor(author.forge().currentUser().id());
             var from = EmailAddress.from("test", "test@test.mail");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(),
-                    listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mlBot = MailingListBridgeBot.newBuilder()
                     .from(from)
                     .repo(author)

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierFactory.java
@@ -95,17 +95,9 @@ public class MailingListNotifierFactory implements NotifierFactory {
     }
 
     private EmailSender emailSender(JSONObject notifierConfiguration) {
-        var hasDelivery = notifierConfiguration.contains("delivery");
-        var hasSmtp = notifierConfiguration.contains("smtp");
-        if (hasDelivery && hasSmtp) {
-            throw new RuntimeException("Only one of mailinglist.delivery or mailinglist.smtp can be configured");
+        if (!notifierConfiguration.contains("delivery")) {
+            throw new RuntimeException("mailinglist.delivery must be configured");
         }
-        if (hasDelivery) {
-            return EmailSenderFactory.create(notifierConfiguration.get("delivery").asObject());
-        }
-        if (hasSmtp) {
-            return new SmtpEmailSender(notifierConfiguration.get("smtp").asString());
-        }
-        throw new RuntimeException("Either mailinglist.delivery or mailinglist.smtp must be configured");
+        return EmailSenderFactory.create(notifierConfiguration.get("delivery").asObject());
     }
 }

--- a/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierFactory.java
+++ b/bots/notify/src/main/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@ package org.openjdk.skara.bots.notify.mailinglist;
 
 import org.openjdk.skara.bot.BotConfiguration;
 import org.openjdk.skara.bots.notify.*;
-import org.openjdk.skara.email.EmailAddress;
+import org.openjdk.skara.email.*;
 import org.openjdk.skara.json.JSONObject;
 import org.openjdk.skara.mailinglist.MailingListServerFactory;
 
@@ -40,10 +40,9 @@ public class MailingListNotifierFactory implements NotifierFactory {
 
     @Override
     public Notifier create(BotConfiguration botConfiguration, JSONObject notifierConfiguration) {
-        var smtp = notifierConfiguration.get("smtp").asString();
         var sender = EmailAddress.parse(notifierConfiguration.get("sender").asString());
         var interval = notifierConfiguration.contains("interval") ? Duration.parse(notifierConfiguration.get("interval").asString()) : Duration.ofSeconds(1);
-        var listServer = MailingListServerFactory.createSendOnlyServer(smtp, interval);
+        var listServer = MailingListServerFactory.createSendOnlyServer(emailSender(notifierConfiguration), interval);
 
         var recipient = notifierConfiguration.get("recipient").asString();
         var recipientAddress = EmailAddress.parse(recipient);
@@ -93,5 +92,20 @@ public class MailingListNotifierFactory implements NotifierFactory {
         }
 
         return builder.build();
+    }
+
+    private EmailSender emailSender(JSONObject notifierConfiguration) {
+        var hasDelivery = notifierConfiguration.contains("delivery");
+        var hasSmtp = notifierConfiguration.contains("smtp");
+        if (hasDelivery && hasSmtp) {
+            throw new RuntimeException("Only one of mailinglist.delivery or mailinglist.smtp can be configured");
+        }
+        if (hasDelivery) {
+            return EmailSenderFactory.create(notifierConfiguration.get("delivery").asObject());
+        }
+        if (hasSmtp) {
+            return new SmtpEmailSender(notifierConfiguration.get("smtp").asString());
+        }
+        throw new RuntimeException("Either mailinglist.delivery or mailinglist.smtp must be configured");
     }
 }

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/NotifyBotFactoryTest.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/NotifyBotFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,10 @@ class NotifyBotFactoryTest {
                       "integrator": "111",
                       "mailinglist": {
                         "archive": "https://test.openjdk.org/archive",
-                        "smtp": "0.0.0.0",
+                        "delivery": {
+                          "type": "smtp",
+                          "server": "0.0.0.0"
+                        },
                         "sender": "test <test@openjdk.org>",
                         "interval": "PT5S"
                       },

--- a/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
+++ b/bots/notify/src/test/java/org/openjdk/skara/bots/notify/mailinglist/MailingListNotifierTests.java
@@ -51,7 +51,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -125,7 +125,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -202,7 +202,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -282,7 +282,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -348,7 +348,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -452,7 +452,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -537,7 +537,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -628,7 +628,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -727,7 +727,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -825,7 +825,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -948,7 +948,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -1045,7 +1045,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -1125,7 +1125,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);
@@ -1192,7 +1192,7 @@ public class MailingListNotifierTests {
             localRepo.pushAll(repo.authenticatedUrl());
 
             var listAddress = listServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), listServer.getSMTP(), Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(listServer.getArchive(), new SmtpEmailSender(listServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var tagStorage = createTagStorage(repo);
             var branchStorage = createBranchStorage(repo);

--- a/email/build.gradle
+++ b/email/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@ module {
 }
 
 dependencies {
+    implementation project(':json')
+
     testImplementation project(':test')
 }
 

--- a/email/src/main/java/module-info.java
+++ b/email/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,10 @@
  */
 module org.openjdk.skara.email {
     requires java.logging;
+    requires org.openjdk.skara.json;
 
     exports org.openjdk.skara.email;
+
+    uses org.openjdk.skara.email.EmailSenderFactory;
+    provides org.openjdk.skara.email.EmailSenderFactory with org.openjdk.skara.email.SmtpEmailSenderFactory;
 }

--- a/email/src/main/java/org/openjdk/skara/email/EmailMessage.java
+++ b/email/src/main/java/org/openjdk/skara/email/EmailMessage.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.email;
+
+import java.time.format.DateTimeFormatter;
+import java.util.stream.Collectors;
+
+public class EmailMessage {
+    public static String toRfc822(Email email) {
+        var recipientList = email.recipients().stream()
+                .map(EmailAddress::toString)
+                .map(MimeText::encode)
+                .collect(Collectors.joining(", "));
+        var ret = new StringBuilder();
+        ret.append("From: ").append(MimeText.encode(email.author().toString())).append("\r\n");
+        ret.append("Message-Id: ").append(email.id()).append("\r\n");
+        ret.append("Date: ").append(email.date().format(DateTimeFormatter.RFC_1123_DATE_TIME)).append("\r\n");
+        ret.append("Sender: ").append(MimeText.encode(email.sender().toString())).append("\r\n");
+        ret.append("To: ").append(recipientList).append("\r\n");
+        for (var header : email.headers()) {
+            ret.append(header).append(": ").append(MimeText.encode(email.headerValue(header))).append("\r\n");
+        }
+        ret.append("Subject: ").append(MimeText.encode(email.subject())).append("\r\n");
+        ret.append("Content-type: text/plain; charset=utf-8").append("\r\n");
+        ret.append("\r\n");
+        ret.append(email.body().replace("\r\n", "\n").replace("\n", "\r\n"));
+        return ret.toString();
+    }
+}

--- a/email/src/main/java/org/openjdk/skara/email/EmailSender.java
+++ b/email/src/main/java/org/openjdk/skara/email/EmailSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,23 +20,10 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.mailinglist.mailman;
+package org.openjdk.skara.email;
 
-import java.time.Duration;
-import org.openjdk.skara.email.EmailAddress;
-import org.openjdk.skara.email.EmailSender;
-import org.openjdk.skara.mailinglist.MailingListReader;
+import java.io.IOException;
 
-/**
- * MailingListServer implementation that only implements the send message API.
- */
-public class SendOnlyServer extends MailmanServer {
-    public SendOnlyServer(EmailSender sender, Duration sendInterval) {
-        super(null, sender, sendInterval, false);
-    }
-
-    @Override
-    public MailingListReader getListReader(EmailAddress... listNames) {
-        throw new UnsupportedOperationException();
-    }
+public interface EmailSender {
+    void send(Email email) throws IOException;
 }

--- a/email/src/main/java/org/openjdk/skara/email/EmailSenderFactory.java
+++ b/email/src/main/java/org/openjdk/skara/email/EmailSenderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -14,29 +14,30 @@
  *
  * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 94065 USA.
  *
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.mailinglist.mailman;
+package org.openjdk.skara.email;
 
-import java.time.Duration;
-import org.openjdk.skara.email.EmailAddress;
-import org.openjdk.skara.email.EmailSender;
-import org.openjdk.skara.mailinglist.MailingListReader;
+import org.openjdk.skara.json.JSONObject;
 
-/**
- * MailingListServer implementation that only implements the send message API.
- */
-public class SendOnlyServer extends MailmanServer {
-    public SendOnlyServer(EmailSender sender, Duration sendInterval) {
-        super(null, sender, sendInterval, false);
-    }
+import java.util.*;
 
-    @Override
-    public MailingListReader getListReader(EmailAddress... listNames) {
-        throw new UnsupportedOperationException();
+public interface EmailSenderFactory {
+    String name();
+
+    EmailSender createSender(JSONObject configuration);
+
+    static EmailSender create(JSONObject configuration) {
+        var type = configuration.get("type").asString();
+        return ServiceLoader.load(EmailSenderFactory.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(factory -> factory.name().equals(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown email sender: " + type))
+                .createSender(configuration);
     }
 }

--- a/email/src/main/java/org/openjdk/skara/email/SMTP.java
+++ b/email/src/main/java/org/openjdk/skara/email/SMTP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import java.io.*;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.format.DateTimeFormatter;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -56,10 +55,7 @@ public class SMTP {
             server = parts[0];
             port = Integer.parseInt(parts[1]);
         }
-        var recipientList = email.recipients().stream()
-                                 .map(EmailAddress::toString)
-                                 .map(MimeText::encode)
-                                 .collect(Collectors.joining(", "));
+        var rawMessage = EmailMessage.toRfc822(email);
         try (var socket = new Socket(server, port);
              var out = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
              var in = new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8)) {
@@ -73,18 +69,7 @@ public class SMTP {
                 session.sendCommand("RCPT TO:<" + recipient.address() + ">", rcptReply);
             }
             session.sendCommand("DATA", dataReply);
-            session.sendCommand("From: " + MimeText.encode(email.author().toString()));
-            session.sendCommand("Message-Id: " + email.id());
-            session.sendCommand("Date: " + email.date().format(DateTimeFormatter.RFC_1123_DATE_TIME));
-            session.sendCommand("Sender: " + MimeText.encode(email.sender().toString()));
-            session.sendCommand("To: " + recipientList);
-            for (var header : email.headers()) {
-                session.sendCommand(header + ": " + MimeText.encode(email.headerValue(header)));
-            }
-            session.sendCommand("Subject: " + MimeText.encode(email.subject()));
-            session.sendCommand("Content-type: text/plain; charset=utf-8");
-            session.sendCommand("");
-            var escapedBody = email.body().lines()
+            var escapedBody = rawMessage.lines()
                                    .map(line -> line.startsWith(".") ? "." + line : line)
                                    .collect(Collectors.joining("\n"));
             session.sendCommand(escapedBody);

--- a/email/src/main/java/org/openjdk/skara/email/SmtpEmailSender.java
+++ b/email/src/main/java/org/openjdk/skara/email/SmtpEmailSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,23 +20,19 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.mailinglist.mailman;
+package org.openjdk.skara.email;
 
-import java.time.Duration;
-import org.openjdk.skara.email.EmailAddress;
-import org.openjdk.skara.email.EmailSender;
-import org.openjdk.skara.mailinglist.MailingListReader;
+import java.io.IOException;
 
-/**
- * MailingListServer implementation that only implements the send message API.
- */
-public class SendOnlyServer extends MailmanServer {
-    public SendOnlyServer(EmailSender sender, Duration sendInterval) {
-        super(null, sender, sendInterval, false);
+public class SmtpEmailSender implements EmailSender {
+    private final String server;
+
+    public SmtpEmailSender(String server) {
+        this.server = server;
     }
 
     @Override
-    public MailingListReader getListReader(EmailAddress... listNames) {
-        throw new UnsupportedOperationException();
+    public void send(Email email) throws IOException {
+        SMTP.send(server, email);
     }
 }

--- a/email/src/main/java/org/openjdk/skara/email/SmtpEmailSenderFactory.java
+++ b/email/src/main/java/org/openjdk/skara/email/SmtpEmailSenderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -20,23 +20,18 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.skara.mailinglist.mailman;
+package org.openjdk.skara.email;
 
-import java.time.Duration;
-import org.openjdk.skara.email.EmailAddress;
-import org.openjdk.skara.email.EmailSender;
-import org.openjdk.skara.mailinglist.MailingListReader;
+import org.openjdk.skara.json.JSONObject;
 
-/**
- * MailingListServer implementation that only implements the send message API.
- */
-public class SendOnlyServer extends MailmanServer {
-    public SendOnlyServer(EmailSender sender, Duration sendInterval) {
-        super(null, sender, sendInterval, false);
+public class SmtpEmailSenderFactory implements EmailSenderFactory {
+    @Override
+    public String name() {
+        return "smtp";
     }
 
     @Override
-    public MailingListReader getListReader(EmailAddress... listNames) {
-        throw new UnsupportedOperationException();
+    public EmailSender createSender(JSONObject configuration) {
+        return new SmtpEmailSender(configuration.get("server").asString());
     }
 }

--- a/email/src/test/java/org/openjdk/skara/email/EmailSenderFactoryTests.java
+++ b/email/src/test/java/org/openjdk/skara/email/EmailSenderFactoryTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.email;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.skara.json.JSON;
+import org.openjdk.skara.test.SMTPServer;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EmailSenderFactoryTests {
+    @Test
+    void smtp() throws IOException {
+        try (var server = new SMTPServer()) {
+            var sender = EmailSenderFactory.create(JSON.object()
+                                                       .put("type", "smtp")
+                                                       .put("server", server.address()));
+            var author = EmailAddress.from("Test", "test@test.email");
+            var recipient = EmailAddress.from("Dest", "dest@dest.email");
+            var sentMail = Email.create(author, "Subject", "Body")
+                                .recipient(recipient)
+                                .build();
+
+            sender.send(sentMail);
+            var email = server.receive(Duration.ofSeconds(10));
+            assertEquals(sentMail, email);
+        }
+    }
+}

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServerFactory.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/MailingListServerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.mailinglist;
 
+import org.openjdk.skara.email.*;
 import org.openjdk.skara.mailinglist.mailman.Mailman2Server;
 import org.openjdk.skara.mailinglist.mailman.Mailman3Server;
 import org.openjdk.skara.mailinglist.mailman.SendOnlyServer;
@@ -32,20 +33,20 @@ import java.nio.file.Path;
 import java.time.Duration;
 
 public class MailingListServerFactory {
-    public static MailingListServer createMailman2Server(URI archive, String smtp, Duration sendInterval) {
-        return new Mailman2Server(archive, smtp, sendInterval, false);
+    public static MailingListServer createMailman2Server(URI archive, EmailSender sender, Duration sendInterval) {
+        return new Mailman2Server(archive, sender, sendInterval, false);
     }
 
-    public static MailingListServer createMailman2Server(URI archive, String smtp, Duration sendInterval, boolean useEtag) {
-        return new Mailman2Server(archive, smtp, sendInterval, useEtag);
+    public static MailingListServer createMailman2Server(URI archive, EmailSender sender, Duration sendInterval, boolean useEtag) {
+        return new Mailman2Server(archive, sender, sendInterval, useEtag);
     }
 
-    public static MailingListServer createMailman3Server(URI archive, String smtp, Duration sendInterval) {
-        return new Mailman3Server(archive, smtp, sendInterval);
+    public static MailingListServer createMailman3Server(URI archive, EmailSender sender, Duration sendInterval) {
+        return new Mailman3Server(archive, sender, sendInterval);
     }
 
-    public static MailingListServer createSendOnlyServer(String smtp, Duration sendInterval) {
-        return new SendOnlyServer(smtp, sendInterval);
+    public static MailingListServer createSendOnlyServer(EmailSender sender, Duration sendInterval) {
+        return new SendOnlyServer(sender, sendInterval);
     }
 
     public static MailingListServer createMboxFileServer(Path file) {

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/Mailman2Server.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/Mailman2Server.java
@@ -29,13 +29,13 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Locale;
 import org.openjdk.skara.email.EmailAddress;
+import org.openjdk.skara.email.EmailSender;
 import org.openjdk.skara.mailinglist.MailingListReader;
 import org.openjdk.skara.network.URIBuilder;
 
 public class Mailman2Server extends MailmanServer {
-
-    public Mailman2Server(URI archive, String smtpServer, Duration sendInterval, boolean useEtag) {
-        super(archive, smtpServer, sendInterval, useEtag);
+    public Mailman2Server(URI archive, EmailSender sender, Duration sendInterval, boolean useEtag) {
+        super(archive, sender, sendInterval, useEtag);
     }
 
     URI getMboxUri(EmailAddress listName, ZonedDateTime month) {

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/Mailman3Server.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/Mailman3Server.java
@@ -27,18 +27,19 @@ import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import org.openjdk.skara.email.EmailAddress;
+import org.openjdk.skara.email.EmailSender;
 import org.openjdk.skara.mailinglist.MailingListReader;
 
 public class Mailman3Server extends MailmanServer {
     private final ZonedDateTime startTime;
 
-    public Mailman3Server(URI archive, String smtpServer, Duration sendInterval, ZonedDateTime startTime) {
-        super(archive, smtpServer, sendInterval, false);
+    public Mailman3Server(URI archive, EmailSender sender, Duration sendInterval, ZonedDateTime startTime) {
+        super(archive, sender, sendInterval, false);
         this.startTime = startTime;
     }
 
-    public Mailman3Server(URI archive, String smtpServer, Duration sendInterval) {
-        this(archive, smtpServer, sendInterval, ZonedDateTime.now());
+    public Mailman3Server(URI archive, EmailSender sender, Duration sendInterval) {
+        this(archive, sender, sendInterval, ZonedDateTime.now());
     }
 
     URI getArchiveUri() {

--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanServer.java
@@ -31,14 +31,14 @@ import java.time.*;
 
 public abstract class MailmanServer implements MailingListServer {
     protected final URI archive;
-    private final String smtpServer;
+    private final EmailSender sender;
     private final Duration sendInterval;
     protected final boolean useEtag;
     private volatile Instant lastSend;
 
-    protected MailmanServer(URI archive, String smtpServer, Duration sendInterval, boolean useEtag) {
+    protected MailmanServer(URI archive, EmailSender sender, Duration sendInterval, boolean useEtag) {
         this.archive = archive;
-        this.smtpServer = smtpServer;
+        this.sender = sender;
         this.sendInterval = sendInterval;
         this.useEtag = useEtag;
         lastSend = Instant.EPOCH;
@@ -53,7 +53,7 @@ public abstract class MailmanServer implements MailingListServer {
         }
         lastSend = Instant.now();
         try {
-            SMTP.send(smtpServer, message);
+            sender.send(message);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/Mailman2Tests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/Mailman2Tests.java
@@ -37,7 +37,7 @@ class Mailman2Tests {
     void simple() throws IOException {
         try (var testServer = TestMailmanServer.createV2()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(), testServer.getSMTP(),
+            var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(), new SmtpEmailSender(testServer.getSMTP()),
                                                                              Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
@@ -62,7 +62,7 @@ class Mailman2Tests {
     void replies() throws IOException {
         try (var testServer = TestMailmanServer.createV2()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(), testServer.getSMTP(),
+            var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(), new SmtpEmailSender(testServer.getSMTP()),
                                                                              Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
@@ -108,7 +108,7 @@ class Mailman2Tests {
     void cached() throws IOException {
         try (var testServer = TestMailmanServer.createV2()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(), testServer.getSMTP(),
+            var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(), new SmtpEmailSender(testServer.getSMTP()),
                                                                              Duration.ZERO, true);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
@@ -142,7 +142,7 @@ class Mailman2Tests {
     void interval() throws IOException {
         try (var testServer = TestMailmanServer.createV2()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(), testServer.getSMTP(),
+            var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(), new SmtpEmailSender(testServer.getSMTP()),
                                                                              Duration.ofDays(1));
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
@@ -175,7 +175,7 @@ class Mailman2Tests {
         try (var testServer = TestMailmanServer.createV2()) {
             var listAddress = testServer.createList("test");
             var mailmanServer = MailingListServerFactory.createMailman2Server(testServer.getArchive(),
-                    testServer.getSMTP(), Duration.ZERO);
+                    new SmtpEmailSender(testServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var now = ZonedDateTime.now();

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/Mailman3Tests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/Mailman3Tests.java
@@ -28,6 +28,7 @@ import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
 import org.openjdk.skara.email.Email;
 import org.openjdk.skara.email.EmailAddress;
+import org.openjdk.skara.email.SmtpEmailSender;
 import org.openjdk.skara.mailinglist.mailman.Mailman3Server;
 import org.openjdk.skara.test.TestMailmanServer;
 
@@ -38,8 +39,7 @@ class Mailman3Tests {
     void simple() throws IOException {
         try (var testServer = TestMailmanServer.createV3()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(testServer.getArchive(), testServer.getSMTP(),
-                                                                             Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(testServer.getArchive(), new SmtpEmailSender(testServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var mail = Email.create(sender, "Subject", "Body")
@@ -63,8 +63,7 @@ class Mailman3Tests {
     void replies() throws IOException {
         try (var testServer = TestMailmanServer.createV3()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(testServer.getArchive(), testServer.getSMTP(),
-                                                                             Duration.ZERO);
+            var mailmanServer = MailingListServerFactory.createMailman3Server(testServer.getArchive(), new SmtpEmailSender(testServer.getSMTP()), Duration.ZERO);
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var sentParent = Email.create(sender, "Subject", "Body")
@@ -109,8 +108,7 @@ class Mailman3Tests {
     void interval() throws IOException {
         try (var testServer = TestMailmanServer.createV3()) {
             var listAddress = testServer.createList("test");
-            var mailmanServer = MailingListServerFactory.createMailman3Server(testServer.getArchive(), testServer.getSMTP(),
-                                                                             Duration.ofDays(1));
+            var mailmanServer = MailingListServerFactory.createMailman3Server(testServer.getArchive(), new SmtpEmailSender(testServer.getSMTP()), Duration.ofDays(1));
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
             var mail1 = Email.create(sender, "Subject 1", "Body 1")
@@ -143,7 +141,7 @@ class Mailman3Tests {
             var listAddress = testServer.createList("test");
             var now = ZonedDateTime.now();
             var mailmanServer = new Mailman3Server(testServer.getArchive(),
-                    testServer.getSMTP(), Duration.ZERO, now.minusDays(2));
+                    new SmtpEmailSender(testServer.getSMTP()), Duration.ZERO, now.minusDays(2));
             var mailmanList = mailmanServer.getListReader(listAddress);
             var sender = EmailAddress.from("Test", "test@test.email");
 


### PR DESCRIPTION
The mailing-list code currently sends mail through SMTP, which makes alternate delivery transports hard to support.

Add an EmailSender abstraction and service-provider based factory so deployments can configure a non-SMTP delivery transport.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2734](https://bugs.openjdk.org/browse/SKARA-2734): Add EmailSender support for mailing list delivery (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1778/head:pull/1778` \
`$ git checkout pull/1778`

Update a local copy of the PR: \
`$ git checkout pull/1778` \
`$ git pull https://git.openjdk.org/skara.git pull/1778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1778`

View PR using the GUI difftool: \
`$ git pr show -t 1778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1778.diff">https://git.openjdk.org/skara/pull/1778.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1778#issuecomment-4596870010)
</details>
