### PR TITLE
2737: MLBridgeBot webrev generator fails when generated webrev  contains .gitignore that ignores other artifacts

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/WebrevStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,7 +211,7 @@ class WebrevStorage {
                                }));
 
             for (var batch : batches.entrySet()) {
-                localStorage.add(batch.getValue());
+                localStorage.forceAdd(batch.getValue());
                 Hash hash;
                 var message = "Added webrev for " + identifier +
                         (batches.size() > 1 ? " (" + (batch.getKey() + 1) + "/" + batches.size() + ")" : "");

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/WebrevStorageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +87,57 @@ class WebrevStorageTests {
             generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
             Repository.materialize(repoFolder, archive.authenticatedUrl(), "webrev");
             assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/index.html")));
+        }
+    }
+
+    @Test
+    void ignoredFilesInWebrev(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var tempFolder = new TemporaryDirectory();
+             var webrevServer = new TestWebrevServer()) {
+            var author = credentials.getHostedRepository();
+            var archive = credentials.getHostedRepository();
+
+            // Populate the projects repository
+            var reviewFile = Path.of("reviewfile.txt");
+            var repoFolder = tempFolder.path().resolve("repo");
+            var localRepo = CheckableRepository.init(repoFolder, author.repositoryType(), reviewFile);
+            var masterHash = localRepo.resolve("master").orElseThrow();
+            localRepo.push(masterHash, author.authenticatedUrl(), "master", true);
+            localRepo.push(masterHash, archive.authenticatedUrl(), "webrev", true);
+
+            // Make a valid source commit where .gitignore ignores a force-added file.
+            var gitignore = repoFolder.resolve(".gitignore");
+            var ignoredFile = repoFolder.resolve("jdk/jdk-packages.json");
+            Files.writeString(gitignore, "jdk/jdk*\n");
+            Files.createDirectories(ignoredFile.getParent());
+            Files.writeString(ignoredFile, "{}\n");
+            localRepo.add(gitignore);
+            localRepo.forceAdd(ignoredFile);
+            var editHash = localRepo.commit("Add ignored file", "duke", "duke@openjdk.org");
+
+            localRepo.push(editHash, author.authenticatedUrl(), "edit", true);
+            var pr = credentials.createPullRequest(archive, "master", "edit", "This is a pull request");
+            pr.addLabel("rfr");
+            pr.setBody("This is now ready");
+
+            var from = EmailAddress.from("test", "test@test.mail");
+            var storage = new WebrevStorage(archive, "webrev", Path.of("test"),
+                                            webrevServer.uri(), from);
+
+            var prFolder = tempFolder.path().resolve("pr");
+            var prRepo = Repository.materialize(prFolder, pr.repository().authenticatedUrl(), "edit");
+            var jsonScratchFolder = tempFolder.path().resolve("scratch").resolve("json");
+            var htmlScratchFolder = tempFolder.path().resolve("scratch").resolve("html");
+            var seedPath = tempFolder.path().resolve("seed");
+            var generator = storage.generator(pr, prRepo, jsonScratchFolder, htmlScratchFolder, new HostedRepositoryPool(seedPath));
+            generator.generate(masterHash, editHash, "00", WebrevDescription.Type.FULL);
+
+            // Update the local repository and check that ignored webrev artifacts were archived.
+            Repository.materialize(repoFolder, archive.authenticatedUrl(), "webrev");
+            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/.gitignore")));
+            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/jdk/jdk-packages.json.html")));
+            assertTrue(Files.exists(repoFolder.resolve("test/" + pr.id() + "/00/jdk/jdk-packages.json.patch")));
         }
     }
 

--- a/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,10 @@ public interface Repository extends ReadOnlyRepository {
     void add(List<Path> files) throws IOException;
     default void add(Path... files) throws IOException {
         add(Arrays.asList(files));
+    }
+    void forceAdd(List<Path> files) throws IOException;
+    default void forceAdd(Path... files) throws IOException {
+        forceAdd(Arrays.asList(files));
     }
     void remove(List<Path> files) throws IOException;
     default void remove(Path... files) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/git/GitRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -744,8 +744,11 @@ public class GitRepository implements Repository {
         }
     }
 
-    private void addAll(List<Path> paths) throws IOException {
+    private void addAll(List<Path> paths, boolean force) throws IOException {
         var cmd = new ArrayList<>(List.of("git", "add"));
+        if (force) {
+            cmd.add("-f");
+        }
         for (var path : paths) {
             cmd.add(path.toString());
         }
@@ -756,7 +759,12 @@ public class GitRepository implements Repository {
 
     @Override
     public void add(List<Path> paths) throws IOException {
-        batch(this::addAll, paths);
+        batch(batch -> addAll(batch, false), paths);
+    }
+
+    @Override
+    public void forceAdd(List<Path> paths) throws IOException {
+        batch(batch -> addAll(batch, true), paths);
     }
 
     private void removeAll(List<Path> paths) throws IOException {

--- a/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
+++ b/vcs/src/main/java/org/openjdk/skara/vcs/hg/HgRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1315,6 +1315,11 @@ public class HgRepository implements Repository {
     @Override
     public void add(List<Path> paths) throws IOException {
         batch(this::addAll, paths);
+    }
+
+    @Override
+    public void forceAdd(List<Path> paths) throws IOException {
+        add(paths);
     }
 
     @Override


### PR DESCRIPTION
MLBridgeBot can fail while archiving generated webrevs if the reviewed changes include a .gitignore file. Webrev publishes a raw copy of changed files into the webrev output directory, so a changed .gitignore becomes an actual .gitignore inside the webrev storage Git checkout. Git then applies those ignore rules while WebrevStorage stages generated artifacts with plain git add, which can cause git add to fail for generated .html or .patch files.

In this case, I think we have no choice but force add.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2737](https://bugs.openjdk.org/browse/SKARA-2737): MLBridgeBot webrev generator fails when generated webrev  contains .gitignore that ignores other artifacts (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1779/head:pull/1779` \
`$ git checkout pull/1779`

Update a local copy of the PR: \
`$ git checkout pull/1779` \
`$ git pull https://git.openjdk.org/skara.git pull/1779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1779`

View PR using the GUI difftool: \
`$ git pr show -t 1779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1779.diff">https://git.openjdk.org/skara/pull/1779.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1779#issuecomment-4634017425)
</details>
