### PR TITLE
2756: Log message filter for logstash needs to be extended to other log handlers

### DIFF
--- a/bot/src/main/java/org/openjdk/skara/bot/BotTaskAggregationHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/BotTaskAggregationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.*;
 
-public abstract class BotTaskAggregationHandler extends StreamHandler {
+public abstract class BotTaskAggregationHandler extends FilteredStreamHandler {
 
     private static class ThreadLogs {
         boolean isPublishing;

--- a/bot/src/main/java/org/openjdk/skara/bot/FilteredStreamHandler.java
+++ b/bot/src/main/java/org/openjdk/skara/bot/FilteredStreamHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bot;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.StreamHandler;
+import java.util.regex.Pattern;
+
+public class FilteredStreamHandler extends StreamHandler {
+    private final List<RegexReplacement> regexReplacements = new ArrayList<>();
+
+    public void addReplacement(String pattern, String replacement) {
+        addReplacement(new RegexReplacement(pattern, replacement));
+    }
+
+    public void addReplacement(RegexReplacement regexReplacement) {
+        regexReplacements.add(regexReplacement);
+    }
+
+    protected String applyReplacements(String s) {
+        CharSequence ret = s;
+        for (RegexReplacement regexReplacement : regexReplacements) {
+            var matcher = regexReplacement.pattern.matcher(ret);
+            var sb = new StringBuilder();
+            while (matcher.find()) {
+                matcher.appendReplacement(sb, regexReplacement.replacement);
+            }
+            matcher.appendTail(sb);
+            ret = sb;
+        }
+        return ret.toString();
+    }
+
+    public record RegexReplacement(Pattern pattern, String replacement) {
+        public RegexReplacement(String pattern, String replacement) {
+            this(Pattern.compile(pattern), replacement);
+        }
+    }
+}

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotConsoleHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotConsoleHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,9 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.logging.*;
+import org.openjdk.skara.bot.FilteredStreamHandler;
 
-class BotConsoleHandler extends StreamHandler {
+class BotConsoleHandler extends FilteredStreamHandler {
 
     private final DateTimeFormatter dateTimeFormatter;
     private final Map<Integer, String> levelAbbreviations;
@@ -55,7 +56,7 @@ class BotConsoleHandler extends StreamHandler {
 
         var level = levelAbbreviations.getOrDefault(record.getLevel().intValue(), "?");
         System.out.println("[" + dateTimeFormatter.format(record.getInstant().truncatedTo(ChronoUnit.SECONDS)) + "][" + record.getLongThreadID() + "][" +
-                level + "] " + record.getMessage());
+                level + "] " + applyReplacements(record.getMessage()));
         var exception = record.getThrown();
         if (exception != null) {
             exception.printStackTrace(System.out);

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,9 +54,19 @@ public class BotLauncher {
             return;
         }
 
+        var globalReplacements = new ArrayList<FilteredStreamHandler.RegexReplacement>();
+        if (config.get("log").asObject().contains("replacements")) {
+            for (var field : config.get("log").asObject().get("replacements").asArray()) {
+                globalReplacements.add(new FilteredStreamHandler.RegexReplacement(
+                        field.get("pattern").asString(), field.get("replacement").asString()));
+            }
+        }
+
         if (config.get("log").asObject().contains("console")) {
-            var level = Level.parse(config.get("log").get("console").get("level").asString());
+            var logConf = config.get("log").get("console");
+            var level = Level.parse(logConf.get("level").asString());
             var handler = new BotConsoleHandler();
+            addReplacements(logConf, handler, globalReplacements);
             handler.setLevel(level);
             log.addHandler(handler);
         }
@@ -81,6 +91,7 @@ public class BotLauncher {
                     prefix == null ? null : prefix.asString(),
                     maxRate,
                     details);
+            addReplacements(slack, handler, globalReplacements);
             handler.setLevel(level);
             log.addHandler(handler);
         }
@@ -101,17 +112,23 @@ public class BotLauncher {
                     }
                 }
             }
-            if (logstashConf.contains("replacements")) {
-                for (var field : logstashConf.get("replacements").asArray()) {
-                    handler.addReplacement(field.get("pattern").asString(), field.get("replacement").asString());
-                }
-            }
+            addReplacements(logstashConf, handler, globalReplacements);
             handler.setLevel(level);
             var dateTimeFormatter = DateTimeFormatter.ISO_INSTANT
                     .withLocale(Locale.getDefault())
                     .withZone(ZoneId.systemDefault());
             handler.addExtraField("instance_start_time", dateTimeFormatter.format(START_TIME));
             log.addHandler(handler);
+        }
+    }
+
+    private static void addReplacements(JSONValue logstashConf, FilteredStreamHandler handler,
+            List<FilteredStreamHandler.RegexReplacement> globalReplacements) {
+        globalReplacements.forEach(handler::addReplacement);
+        if (logstashConf.contains("replacements")) {
+            for (var field : logstashConf.get("replacements").asArray()) {
+                handler.addReplacement(field.get("pattern").asString(), field.get("replacement").asString());
+            }
         }
     }
 

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotLogstashHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,7 @@
  */
 package org.openjdk.skara.bots.cli;
 
+import org.openjdk.skara.bot.FilteredStreamHandler;
 import org.openjdk.skara.bot.LogContextMap;
 import org.openjdk.skara.json.JSON;
 
@@ -40,16 +41,12 @@ import java.util.regex.Pattern;
  * Handles logging to logstash. Be careful not to call anything that creates new
  * log records from this class as that can cause infinite recursion.
  */
-public class BotLogstashHandler extends StreamHandler {
+public class BotLogstashHandler extends FilteredStreamHandler {
     private final URI endpoint;
     private final HttpClient httpClient;
     private final DateTimeFormatter dateTimeFormatter;
     // Optionally store all futures for testing purposes
     private Collection<Future<HttpResponse<Void>>> futures;
-
-    private record RegexReplacement(Pattern pattern, String replacement) {}
-
-    private final List<RegexReplacement> regexReplacements = new ArrayList<>();
 
     private static class ExtraField {
         String name;
@@ -85,10 +82,6 @@ public class BotLogstashHandler extends StreamHandler {
         extraFields.add(extraField);
     }
 
-    void addReplacement(String pattern, String replacement) {
-        regexReplacements.add(new RegexReplacement(Pattern.compile(pattern), replacement));
-    }
-
     private Map<String, String> getExtraFields(LogRecord record) {
         var ret = new HashMap<String, String>();
         for (var extraField : extraFields) {
@@ -103,20 +96,6 @@ public class BotLogstashHandler extends StreamHandler {
             }
         }
         return ret;
-    }
-
-    private String applyReplacements(String s) {
-        CharSequence ret = s;
-        for (RegexReplacement regexReplacement : regexReplacements) {
-            var matcher = regexReplacement.pattern.matcher(ret);
-            var sb = new StringBuilder();
-            while (matcher.find()) {
-                matcher.appendReplacement(sb, regexReplacement.replacement);
-            }
-            matcher.appendTail(sb);
-            ret = sb;
-        }
-        return ret.toString();
     }
 
     @Override

--- a/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotSlackHandler.java
+++ b/bots/cli/src/main/java/org/openjdk/skara/bots/cli/BotSlackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,7 +127,7 @@ class BotSlackHandler extends BotTaskAggregationHandler {
         if (prefix != null) {
             message.append(prefix);
         }
-        message.append("`").append(record.getLevel().getName()).append("` ").append(record.getMessage());
+        message.append("`").append(record.getLevel().getName()).append("` ").append(applyReplacements(record.getMessage()));
         return message.toString();
     }
 }

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotLogstashHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotLogstashHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,6 +153,30 @@ class BotLogstashHandlerTests {
             assertEquals("ello", requests.get(0).get("optional1").asString());
             assertFalse(requests.get(0).contains("optional2"));
             assertEquals("ye", requests.get(2).get("optional3").asString());
+        }
+    }
+
+    @Test
+    void applyReplacements() throws IOException, ExecutionException, InterruptedException {
+        try (var receiver = new RestReceiver()) {
+            var handler = new BotLogstashHandler(receiver.getEndpoint());
+            handler.addReplacement("Hello", "Goodbye");
+            var futures = new ArrayList<Future<HttpResponse<Void>>>();
+            handler.setFuturesCollection(futures);
+
+            var record = new LogRecord(Level.INFO, "Hello");
+            record.setLoggerName("my.logger");
+            handler.publish(record);
+
+            for (Future<HttpResponse<Void>> future : futures) {
+                future.get();
+            }
+
+            var requests = receiver.getRequests();
+            assertEquals(1, requests.size(), requests.toString());
+            assertEquals("Goodbye", requests.get(0).get("message").asString());
+            assertEquals(Level.INFO.getName(), requests.get(0).get("level").asString());
+            assertEquals("my.logger", requests.get(0).get("logger_name").asString());
         }
     }
 }

--- a/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
+++ b/bots/cli/src/test/java/org/openjdk/skara/bots/cli/BotSlackHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -211,6 +211,21 @@ class BotSlackHandlerTests {
             var attachment = request.get("attachments").asArray().get(0);
             assertTrue(attachment.get("title_link").asString().contains("go.to/def"));
         }
+    }
 
+    @Test
+    void applyReplacements() throws IOException {
+
+        try (var receiver = new RestReceiver()) {
+            var handler = new BotSlackHandler(receiver.getEndpoint(), "test", "`testc` ", Duration.ofSeconds(1), new HashMap<>());
+            handler.addReplacement("Hello", "Goodbye");
+            var record = new LogRecord(Level.INFO, "Hello");
+            handler.publish(record);
+
+            var requests = receiver.getRequests();
+            assertEquals(1, requests.size(), requests.toString());
+            assertEquals("test", requests.get(0).get("username").asString());
+            assertEquals("`testc` `INFO` Goodbye", requests.get(0).get("text").asString());
+        }
     }
 }


### PR DESCRIPTION
In [SKARA-1635](https://bugs.openjdk.org/browse/SKARA-1635) I added configurable regex message filters to BotLogstashHandler. This configuration needs to apply to other log handlers as well. In this patch I'm achieving this by extracting a common super class for all the log handlers and making the configuration accept global filter patterns that apply to all log handlers.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2756](https://bugs.openjdk.org/browse/SKARA-2756): Log message filter for logstash needs to be extended to other log handlers (**Bug** - P3)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1780/head:pull/1780` \
`$ git checkout pull/1780`

Update a local copy of the PR: \
`$ git checkout pull/1780` \
`$ git pull https://git.openjdk.org/skara.git pull/1780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1780`

View PR using the GUI difftool: \
`$ git pr show -t 1780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1780.diff">https://git.openjdk.org/skara/pull/1780.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1780#issuecomment-4845685798)
</details>
