### PR TITLE
2762: Prevent individual external PR failures from blocking IssueBot processing

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@ package org.openjdk.skara.bots.pr;
 import org.openjdk.skara.bot.Bot;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.HostedRepository;
-import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.IssueProjectPoller;
 import org.openjdk.skara.issuetracker.IssueProject;
 
@@ -87,17 +86,26 @@ class IssueBot implements Bot {
             if (prRecords == null) {
                 continue;
             }
-            prRecords.stream()
-                    .flatMap(record -> repositories.stream()
-                            .filter(r -> r.name().equals(record.repoName()))
-                            .map(r -> r.pullRequest(record.prId()))
-                    )
-                    .filter(Issue::isOpen)
-                    // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
-                    // best we can do.
-                    .map(pr -> CheckWorkItem.fromIssueBot(pullRequestBotMap.get(pr.repository().name()), pr.id(),
-                            e -> poller.retryIssue(issue), issue.updatedAt()))
-                    .forEach(items::add);
+            for (var record : prRecords) {
+                for (var repository : repositories) {
+                    if (!repository.name().equals(record.repoName())) {
+                        continue;
+                    }
+                    try {
+                        var pr = repository.pullRequest(record.prId());
+                        if (pr.isOpen()) {
+                            // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
+                            // best we can do.
+                            items.add(CheckWorkItem.fromIssueBot(pullRequestBotMap.get(pr.repository().name()), pr.id(),
+                                    e -> poller.retryIssue(issue), issue.updatedAt()));
+                        }
+                    } catch (RuntimeException e) {
+                        log.warning("Failed to retrieve pull request " + record.prId() + " from " + repository.name()
+                                + " for issue " + issue.id() + "; will retry the issue: " + e.getMessage());
+                        poller.retryIssue(issue);
+                    }
+                }
+            }
         }
         poller.lastBatchHandled();
         return items;

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
@@ -25,6 +25,7 @@ package org.openjdk.skara.bots.pr;
 import org.openjdk.skara.bot.Bot;
 import org.openjdk.skara.bot.WorkItem;
 import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.issuetracker.Issue;
 import org.openjdk.skara.issuetracker.IssueProjectPoller;
 import org.openjdk.skara.issuetracker.IssueProject;
 
@@ -35,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
+
 import org.openjdk.skara.issuetracker.IssueTrackerIssue;
 
 class IssueBot implements Bot {
@@ -90,18 +93,18 @@ class IssueBot implements Bot {
             prRecords.stream()
                     .flatMap(record -> repositories.stream()
                             .filter(r -> r.name().equals(record.repoName()))
-                            .map(r -> {
+                            .flatMap(r -> {
                                 try {
-                                    return r.pullRequest(record.prId());
+                                    return Stream.of(r.pullRequest(record.prId()));
                                 } catch (RuntimeException e) {
                                     log.log(Level.WARNING, "Failed to retrieve pull request " + record.prId() + " from "
                                             + r.name() + " for issue " + issue.id() + "; will retry the issue", e);
                                     poller.retryIssue(issue);
-                                    return null;
+                                    return Stream.empty();
                                 }
                             })
                     )
-                    .filter(pr -> pr != null && pr.isOpen())
+                    .filter(Issue::isOpen)
                     // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
                     // best we can do.
                     .map(pr -> CheckWorkItem.fromIssueBot(pullRequestBotMap.get(pr.repository().name()), pr.id(),

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
@@ -31,9 +31,11 @@ import org.openjdk.skara.issuetracker.IssueProject;
 
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -85,6 +87,7 @@ class IssueBot implements Bot {
         var issues = poller.updatedIssues();
         log.info("Found " + issues.size() + " updated issues(exclude CSR issues)");
         var items = new LinkedList<WorkItem>();
+        Set<IssueTrackerIssue> issuesToRetry = new HashSet<>();
         for (var issue : issues) {
             var prRecords = issuePRMap.get(issue.id());
             if (prRecords == null) {
@@ -99,7 +102,7 @@ class IssueBot implements Bot {
                                 } catch (RuntimeException e) {
                                     log.log(Level.WARNING, "Failed to retrieve pull request " + record.prId() + " from "
                                             + r.name() + " for issue " + issue.id() + "; will retry the issue", e);
-                                    poller.retryIssue(issue);
+                                    issuesToRetry.add(issue);
                                     return Stream.empty();
                                 }
                             })
@@ -112,6 +115,7 @@ class IssueBot implements Bot {
                     .forEach(items::add);
         }
         poller.lastBatchHandled();
+        issuesToRetry.forEach(poller::retryIssue);
         return items;
     }
 

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/IssueBot.java
@@ -33,6 +33,7 @@ import java.time.ZonedDateTime;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.openjdk.skara.issuetracker.IssueTrackerIssue;
 
@@ -86,26 +87,26 @@ class IssueBot implements Bot {
             if (prRecords == null) {
                 continue;
             }
-            for (var record : prRecords) {
-                for (var repository : repositories) {
-                    if (!repository.name().equals(record.repoName())) {
-                        continue;
-                    }
-                    try {
-                        var pr = repository.pullRequest(record.prId());
-                        if (pr.isOpen()) {
-                            // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
-                            // best we can do.
-                            items.add(CheckWorkItem.fromIssueBot(pullRequestBotMap.get(pr.repository().name()), pr.id(),
-                                    e -> poller.retryIssue(issue), issue.updatedAt()));
-                        }
-                    } catch (RuntimeException e) {
-                        log.warning("Failed to retrieve pull request " + record.prId() + " from " + repository.name()
-                                + " for issue " + issue.id() + "; will retry the issue: " + e.getMessage());
-                        poller.retryIssue(issue);
-                    }
-                }
-            }
+            prRecords.stream()
+                    .flatMap(record -> repositories.stream()
+                            .filter(r -> r.name().equals(record.repoName()))
+                            .map(r -> {
+                                try {
+                                    return r.pullRequest(record.prId());
+                                } catch (RuntimeException e) {
+                                    log.log(Level.WARNING, "Failed to retrieve pull request " + record.prId() + " from "
+                                            + r.name() + " for issue " + issue.id() + "; will retry the issue", e);
+                                    poller.retryIssue(issue);
+                                    return null;
+                                }
+                            })
+                    )
+                    .filter(pr -> pr != null && pr.isOpen())
+                    // This will mix time stamps from the IssueTracker and the Forge hosting PRs, but it's the
+                    // best we can do.
+                    .map(pr -> CheckWorkItem.fromIssueBot(pullRequestBotMap.get(pr.repository().name()), pr.id(),
+                            e -> poller.retryIssue(issue), issue.updatedAt()))
+                    .forEach(items::add);
         }
         poller.lastBatchHandled();
         return items;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -442,6 +442,31 @@ public class IssueBotTests {
                             "[/approval](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/approval) command." +
                             "<!-- PullRequestBot approval needed comment -->"
                     , pr.store().comments().get(2).body());
+        }
+    }
+
+    @Test
+    void missingPullRequestDoesNotBlockOtherPullRequests(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo)) {
+            var repository = credentials.getHostedRepository();
+            var issueProject = credentials.getIssueProject();
+            var issue = issueProject.createIssue("This is an issue", List.of(), Map.of());
+            issue.setProperty("issuetype", JSON.of("Bug"));
+
+            Map<String, List<PRRecord>> issuePRMap = new HashMap<>();
+            var issueBot = new IssueBot(issueProject, List.of(repository), Map.of(), issuePRMap);
+
+            // Initialize the poller before adding the PR records.
+            assertTrue(issueBot.getPeriodicItems().isEmpty());
+
+            var pr = credentials.createPullRequest(repository, "master", "edit", issue.id() + ": This is an issue");
+            issuePRMap.put(issue.id(), List.of(
+                    new PRRecord(repository.name(), "missing"),
+                    new PRRecord(repository.name(), pr.id())));
+            issue.setProperty("priority", JSON.of("4"));
+
+            // A disappeared PR is retried with the issue, but must not prevent work for another PR.
+            assertEquals(1, issueBot.getPeriodicItems().size());
         }
     }
 }

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/IssueBotTests.java
@@ -465,7 +465,10 @@ public class IssueBotTests {
                     new PRRecord(repository.name(), pr.id())));
             issue.setProperty("priority", JSON.of("4"));
 
-            // A disappeared PR is retried with the issue, but must not prevent work for another PR.
+            // A disappeared PR must not prevent work for another PR.
+            assertEquals(1, issueBot.getPeriodicItems().size());
+
+            // The failed lookup should cause the issue to be retried.
             assertEquals(1, issueBot.getPeriodicItems().size());
         }
     }


### PR DESCRIPTION
IssueBot previously processed all PRs associated with an updated issue through a single stream. If fetching any one external PR failed, the exception terminated the whole stream. Therefore, valid PRs were not processed and no CheckWorkItems were created for them. The periodic batch also did not complete normally.

We should process each associated PR independently instead. When a PR query fails, log the failure and schedule the issue for retry in a later polling round. Continue creating CheckWorkItems for the remaining PRs in the current round, so a transient or broken external PR cannot block unrelated valid PRs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2762](https://bugs.openjdk.org/browse/SKARA-2762): Prevent individual external PR failures from blocking IssueBot processing (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1781/head:pull/1781` \
`$ git checkout pull/1781`

Update a local copy of the PR: \
`$ git checkout pull/1781` \
`$ git pull https://git.openjdk.org/skara.git pull/1781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1781`

View PR using the GUI difftool: \
`$ git pr show -t 1781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1781.diff">https://git.openjdk.org/skara/pull/1781.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1781#issuecomment-4938051941)
</details>
