### PR TITLE
2782: Disable summary command

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1118,7 +1118,10 @@ class CheckRun {
         message.append("\n```\n");
 
         message.append("You can use [pull request commands](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands) ");
-        message.append("such as [/summary](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/summary), ");
+        message.append("such as ");
+        if (workItem.bot.summaryCommandEnabled()) {
+            message.append("[/summary](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/summary), ");
+        }
         message.append("[/contributor](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/contributor) and ");
         message.append("[/issue](https://wiki.openjdk.org/display/SKARA/Pull+Request+Commands#PullRequestCommands-/issue) to adjust it as needed.");
         message.append("\n\n");

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBot.java
@@ -85,6 +85,7 @@ class PullRequestBot implements Bot {
     private boolean initialRun = true;
     private final boolean versionMismatchWarning;
     private final boolean cleanCommandEnabled;
+    private final boolean summaryCommandEnabled;
     private final boolean checkContributorStatusForBackportCommand;
     private final List<String> requiredCheckedLines;
     private final List<TrailerCommand.TrailerConfig> trailerConfigs;
@@ -102,7 +103,7 @@ class PullRequestBot implements Bot {
                    boolean reviewCleanBackport, String mlbridgeBotName, MergePullRequestReviewConfiguration reviewMerge, boolean processPR, boolean processCommit,
                    boolean enableMerge, Set<String> mergeSources, boolean jcheckMerge, boolean enableBackport,
                    Map<String, List<PRRecord>> issuePRMap, Approval approval, boolean versionMismatchWarning, boolean cleanCommandEnabled,
-                   boolean checkContributorStatusForBackportCommand, List<String> requiredCheckedLines,
+                   boolean summaryCommandEnabled, boolean checkContributorStatusForBackportCommand, List<String> requiredCheckedLines,
                    List<TrailerCommand.TrailerConfig> trailerConfigs, int workItemBatchSize) {
         remoteRepo = repo;
         this.censusRepo = censusRepo;
@@ -142,6 +143,7 @@ class PullRequestBot implements Bot {
         this.approval = approval;
         this.versionMismatchWarning = versionMismatchWarning;
         this.cleanCommandEnabled = cleanCommandEnabled;
+        this.summaryCommandEnabled = summaryCommandEnabled;
         this.checkContributorStatusForBackportCommand = checkContributorStatusForBackportCommand;
         this.requiredCheckedLines = requiredCheckedLines;
         this.trailerConfigs = trailerConfigs;
@@ -467,6 +469,10 @@ class PullRequestBot implements Bot {
 
     public boolean cleanCommandEnabled() {
         return cleanCommandEnabled;
+    }
+
+    public boolean summaryCommandEnabled() {
+        return summaryCommandEnabled;
     }
 
     public boolean checkContributorStatusForBackportCommand() {

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotBuilder.java
@@ -69,6 +69,7 @@ public class PullRequestBotBuilder {
     private Approval approval = null;
     private boolean versionMismatchWarning = false;
     private boolean cleanCommandEnabled = true;
+    private boolean summaryCommandEnabled = false;
     private boolean checkContributorStatusForBackportCommand = true;
     private List<String> requiredCheckedLines = new ArrayList<String>();
     private List<TrailerCommand.TrailerConfig> trailerConfigs = List.of();
@@ -267,6 +268,11 @@ public class PullRequestBotBuilder {
         return this;
     }
 
+    public PullRequestBotBuilder summaryCommandEnabled(boolean summaryCommandEnabled) {
+        this.summaryCommandEnabled = summaryCommandEnabled;
+        return this;
+    }
+
     public PullRequestBotBuilder checkContributorStatusForBackportCommand(boolean checkContributorStatusForBackportCommand) {
         this.checkContributorStatusForBackportCommand = checkContributorStatusForBackportCommand;
         return this;
@@ -294,6 +300,6 @@ public class PullRequestBotBuilder {
                 confOverrideName, confOverrideRef, censusLink, forks, integrators, excludeCommitCommentsFrom, enableCsr,
                 enableJep, reviewCleanBackport, mlbridgeBotName, reviewMerge, processPR, processCommit, enableMerge,
                 mergeSources, jcheckMerge, enableBackport, issuePRMap, approval, versionMismatchWarning, cleanCommandEnabled,
-                checkContributorStatusForBackportCommand, requiredCheckedLines, trailerConfigs, workItemBatchSize);
+                summaryCommandEnabled, checkContributorStatusForBackportCommand, requiredCheckedLines, trailerConfigs, workItemBatchSize);
     }
 }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/PullRequestBotFactory.java
@@ -285,6 +285,10 @@ public class PullRequestBotFactory implements BotFactory {
                 botBuilder.cleanCommandEnabled(repo.value().get("cleanCommandEnabled").asBoolean());
             }
 
+            if (repo.value().contains("summaryCommandEnabled")) {
+                botBuilder.summaryCommandEnabled(repo.value().get("summaryCommandEnabled").asBoolean());
+            }
+
             if (repo.value().contains("checkContributorStatusForBackportCommand")) {
                 botBuilder.checkContributorStatusForBackportCommand(repo.value().get("checkContributorStatusForBackportCommand").asBoolean());
             }

--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SummaryCommand.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/SummaryCommand.java
@@ -36,6 +36,11 @@ public class SummaryCommand implements CommandHandler {
     private static final Pattern INVALID_SUMMARY_PATTERN = Pattern.compile("(^(Co-authored-by:)(.*))|(^(Reviewed-by:)(.*))|(^(Backport-of:)(.*))|(^[0-9]+:(.*))");
     @Override
     public void handle(PullRequestBot bot, PullRequest pr, CensusInstance censusInstance, ScratchArea scratchArea, CommandInvocation command, List<Comment> allComments, PrintWriter reply) {
+        if (!bot.summaryCommandEnabled()) {
+            reply.println("The `/summary` pull request command is not enabled for this repository");
+            return;
+        }
+
         if (!command.user().equals(pr.author())) {
             reply.println("Only the author (@" + pr.author().username() + ") is allowed to issue the `/summary` command.");
             return;

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/CheckTests.java
@@ -2441,6 +2441,7 @@ class CheckTests {
             var numComments = comments.size();
             assertLastCommentContains(pr, "the full name on your profile does not match the author name");
             assertFirstCommentContains(pr, "This change now passes all *automated* pre-integration checks.");
+            assertFalse(pr.comments().getFirst().body().contains("[/summary]"));
 
             // Run the bot again, should not result in any new comments
             TestBotRunner.runPeriodicItems(mergeBot);

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestBotFactoryTest.java
@@ -92,6 +92,7 @@ class PullRequestBotFactoryTest {
                             "integrator2"
                           ],
                           "reviewCleanBackport": true,
+                          "summaryCommandEnabled": true,
                           "mergeSources": [
                             "openjdk/playground",
                             "openjdk/skara",
@@ -223,6 +224,7 @@ class PullRequestBotFactoryTest {
             assertTrue(pullRequestBot2.mergeSources().contains("openjdk/playground"));
             assertFalse(pullRequestBot2.jcheckMerge());
             assertFalse(pullRequestBot2.enableBackport());
+            assertTrue(pullRequestBot2.summaryCommandEnabled());
             assertEquals(List.of("foo"), pullRequestBot2.requiredCheckedLines());
             assertEquals(1, pullRequestBot2.trailerConfigs().size());
             TrailerCommand.TrailerConfig trailerConfig = pullRequestBot2.trailerConfigs().getFirst();
@@ -242,6 +244,7 @@ class PullRequestBotFactoryTest {
             assertTrue(pullRequestBot5.enableBackport());
             assertFalse(pullRequestBot5.versionMismatchWarning());
             assertTrue(pullRequestBot5.cleanCommandEnabled());
+            assertFalse(pullRequestBot5.summaryCommandEnabled());
             assertEquals(List.of("bar"), pullRequestBot5.requiredCheckedLines());
             assertEquals(1, pullRequestBot5.trailerConfigs().size());
 

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/PullRequestCommandTests.java
@@ -121,7 +121,7 @@ class PullRequestCommandTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -323,7 +323,7 @@ class PullRequestCommandTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SponsorTests.java
@@ -985,7 +985,7 @@ class SponsorTests {
                     .addReviewer(reviewer2.forge().currentUser().id())
                     .addAuthor(author.forge().currentUser().id());
 
-            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).useStaleReviews(false).build();
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).useStaleReviews(false).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.*;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertFirstCommentContains;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 class SummaryTests {
@@ -44,7 +45,7 @@ class SummaryTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -91,6 +92,7 @@ class SummaryTests {
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
+            assertFirstCommentContains(pr, "[/summary]");
 
             // Now update it
             pr.addComment("/summary Third time is surely the charm");
@@ -144,7 +146,7 @@ class SummaryTests {
 
             var censusBuilder = credentials.getCensusBuilder()
                                            .addAuthor(author.forge().currentUser().id());
-            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var mergeBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepo = CheckableRepository.init(tempFolder.path(), author.repositoryType());
@@ -180,7 +182,7 @@ class SummaryTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -266,7 +268,7 @@ class SummaryTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -312,7 +314,7 @@ class SummaryTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -358,7 +360,7 @@ class SummaryTests {
             var censusBuilder = credentials.getCensusBuilder()
                                            .addReviewer(integrator.forge().currentUser().id())
                                            .addCommitter(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");
@@ -397,7 +399,7 @@ class SummaryTests {
             var censusBuilder = credentials.getCensusBuilder()
                     .addReviewer(integrator.forge().currentUser().id())
                     .addCommitter(author.forge().currentUser().id());
-            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).build();
+            var prBot = PullRequestBot.newBuilder().repo(integrator).censusRepo(censusBuilder.build()).summaryCommandEnabled(true).build();
 
             // Populate the projects repository
             var localRepoFolder = tempFolder.path().resolve("localrepo");

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/SummaryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.*;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertFirstCommentContains;
 import static org.openjdk.skara.bots.pr.PullRequestAsserts.assertLastCommentContains;
 
 class SummaryTests {
@@ -92,7 +91,7 @@ class SummaryTests {
             approvalPr.addReview(Review.Verdict.APPROVED, "Approved");
             TestBotRunner.runPeriodicItems(prBot);
             TestBotRunner.runPeriodicItems(prBot);
-            assertFirstCommentContains(pr, "[/summary]");
+            assertTrue(pr.store().comments().get(1).body().contains("[/summary]"));
 
             // Now update it
             pr.addComment("/summary Third time is surely the charm");


### PR DESCRIPTION
The summary command allows users to bring arbitrary text in commit messages. We should disable this command.

This command will be disabled by default for all repos and can be enabled explicitly.

Also for the merge ready comment, if summary command is disabled, then it won't be mentioned.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2782](https://bugs.openjdk.org/browse/SKARA-2782): Disable summary command (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1782/head:pull/1782` \
`$ git checkout pull/1782`

Update a local copy of the PR: \
`$ git checkout pull/1782` \
`$ git pull https://git.openjdk.org/skara.git pull/1782/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1782`

View PR using the GUI difftool: \
`$ git pr show -t 1782`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1782.diff">https://git.openjdk.org/skara/pull/1782.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1782#issuecomment-5207886958)
</details>
