### PR TITLE
2784: Clean label left on PR when changed from merge to regular

### DIFF
--- a/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
+++ b/bots/pr/src/main/java/org/openjdk/skara/bots/pr/CheckRun.java
@@ -1442,6 +1442,8 @@ class CheckRun {
             var isCleanBackport = false;
             if (original.isPresent()) {
                 isCleanBackport = updateClean(original.get());
+            } else if (!PullRequestUtils.isMerge(pr)) {
+                newLabels.remove("clean");
             }
 
             List<String> additionalErrors = List.of();

--- a/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
+++ b/bots/pr/src/test/java/org/openjdk/skara/bots/pr/MergeTests.java
@@ -1766,6 +1766,12 @@ class MergeTests {
             TestBotRunner.runPeriodicItems(mergeBot);
 
             assertTrue(pr.store().labelNames().contains("clean"));
+
+            // Change the title so that this is no longer a merge-style PR
+            pr.setTitle("123: Not a merge PR");
+            TestBotRunner.runPeriodicItems(mergeBot);
+
+            assertFalse(pr.store().labelNames().contains("clean"));
         }
     }
 


### PR DESCRIPTION
Currently, if a PR is initially treated as a merge-style PR and a clean label is added, the label is not removed when the PR is later converted to a normal PR.
This PR ensures that the clean label is removed from PRs that are neither backport PRs nor merge-style PRs.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2784](https://bugs.openjdk.org/browse/SKARA-2784): Clean label left on PR when changed from merge to regular (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1783/head:pull/1783` \
`$ git checkout pull/1783`

Update a local copy of the PR: \
`$ git checkout pull/1783` \
`$ git pull https://git.openjdk.org/skara.git pull/1783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1783`

View PR using the GUI difftool: \
`$ git pr show -t 1783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1783.diff">https://git.openjdk.org/skara/pull/1783.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1783#issuecomment-5286213672)
</details>
