### PR TITLE
2785: Mailman3 archive reader keeps failing after receiving bad gzip response

### DIFF
--- a/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
+++ b/mailinglist/src/main/java/org/openjdk/skara/mailinglist/mailman/MailmanListReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,12 +219,12 @@ class Mailman3ListReader extends MailmanListReader {
                 if (end.isBefore(now) && pageCache.containsKey(mboxUri)) {
                     var cachedResponse = pageCache.get(mboxUri);
                     if (cachedResponse != null && cachedResponse.statusCode() != 404) {
-                        emails.addAll(0, Mbox.splitMbox(gunzipToString(cachedResponse.body()), sender));
+                        emails.addAll(0, splitMbox(mboxUri, cachedResponse, sender));
                     }
                 } else {
                     var mboxResponse = getPage(mboxUri);
                     if (mboxResponse.isPresent()) {
-                        emails.addAll(0, Mbox.splitMbox(gunzipToString(mboxResponse.get().body()), sender));
+                        emails.addAll(0, splitMbox(mboxUri, mboxResponse.get(), sender));
                         newContent = true;
                     }
                 }
@@ -239,6 +239,17 @@ class Mailman3ListReader extends MailmanListReader {
         }
 
         return cachedConversations;
+    }
+
+    private List<Email> splitMbox(URI uri, HttpResponse<byte[]> response, EmailAddress sender) {
+        String mbox;
+        try {
+            mbox = gunzipToString(response.body());
+        } catch (UncheckedIOException e) {
+            pageCache.remove(uri, response);
+            throw e;
+        }
+        return Mbox.splitMbox(mbox, sender);
     }
 
     private String gunzipToString(byte[] data) {

--- a/mailinglist/src/test/java/org/openjdk/skara/mailinglist/Mailman3Tests.java
+++ b/mailinglist/src/test/java/org/openjdk/skara/mailinglist/Mailman3Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.skara.mailinglist;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
@@ -101,6 +102,28 @@ class Mailman3Tests {
             assertEquals(1, replies.size());
             var reply = replies.get(0);
             assertEquals(expectedReply, reply);
+        }
+    }
+
+    @Test
+    void discardsTruncatedArchiveResponse() throws IOException {
+        try (var testServer = TestMailmanServer.createV3()) {
+            var listAddress = testServer.createList("test");
+            var startTime = ZonedDateTime.now().minusDays(1);
+            var mailmanServer = new Mailman3Server(testServer.getArchive(),
+                    new SmtpEmailSender(testServer.getSMTP()), Duration.ZERO, startTime);
+            var mailmanList = mailmanServer.getListReader(listAddress);
+            var mail = Email.create(EmailAddress.from("Test", "test@test.email"), "Subject", "Body")
+                            .recipient(listAddress)
+                            .build();
+            mailmanServer.post(mail);
+            testServer.processIncoming();
+
+            testServer.truncateNextResponse();
+            assertThrows(UncheckedIOException.class, () -> mailmanList.conversations(Duration.ofDays(1)));
+
+            var conversations = mailmanList.conversations(Duration.ofDays(1));
+            assertEquals(1, conversations.size());
         }
     }
 

--- a/test/src/main/java/org/openjdk/skara/test/TestMailmanServer.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestMailmanServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ public abstract class TestMailmanServer implements AutoCloseable {
     private final SMTPServer smtpServer;
     private int callCount = 0;
     private boolean lastResponseCached;
+    private boolean truncateNextResponse;
 
     public static TestMailmanServer createV2() throws IOException {
         return new TestMailman2Server();
@@ -63,6 +64,10 @@ public abstract class TestMailmanServer implements AutoCloseable {
                 exchange.sendResponseHeaders(404, 0);
                 exchange.close();
                 return;
+            }
+            if (truncateNextResponse) {
+                mboxContents = Arrays.copyOf(mboxContents, mboxContents.length - 1);
+                truncateNextResponse = false;
             }
             lastResponseCached = false;
 
@@ -148,6 +153,13 @@ public abstract class TestMailmanServer implements AutoCloseable {
 
     public int callCount() {
         return callCount;
+    }
+
+    /**
+     * Makes the next archive response invalid by omitting its final byte.
+     */
+    public void truncateNextResponse() {
+        truncateNextResponse = true;
     }
 }
 


### PR DESCRIPTION
Mailman 3 can return a truncated gzip response. Because the response is cached before decompression, subsequent runs keep failing until the bot restarts.

With this PR, the bot will remove the invalid response from the cache when decompression fails.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2785](https://bugs.openjdk.org/browse/SKARA-2785): Mailman3 archive reader keeps failing after receiving bad gzip response (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1784/head:pull/1784` \
`$ git checkout pull/1784`

Update a local copy of the PR: \
`$ git checkout pull/1784` \
`$ git pull https://git.openjdk.org/skara.git pull/1784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1784`

View PR using the GUI difftool: \
`$ git pr show -t 1784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1784.diff">https://git.openjdk.org/skara/pull/1784.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1784#issuecomment-5286773962)
</details>
