### PR TITLE
2789: Fall back to local seed when reading an archive file times out

### DIFF
--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveFileReader.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveFileReader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import org.openjdk.skara.forge.*;
+
+import java.io.*;
+import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+class ArchiveFileReader {
+    private final HostedRepository archiveRepository;
+    private final String archiveRef;
+    private final HostedRepositoryPool repositoryPool;
+    private final Logger log = Logger.getLogger("org.openjdk.skara.bots.mlbridge");
+
+    ArchiveFileReader(HostedRepository archiveRepository, String archiveRef, Path seedStorage) {
+        this.archiveRepository = archiveRepository;
+        this.archiveRef = archiveRef;
+        repositoryPool = new HostedRepositoryPool(seedStorage);
+    }
+
+    private boolean causedByTimeout(UncheckedIOException exception) {
+        Throwable cause = exception;
+        while (cause != null) {
+            if (cause instanceof HttpTimeoutException) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+
+    Optional<String> fileContents(String filename) {
+        try {
+            return archiveRepository.fileContents(filename, archiveRef);
+        } catch (UncheckedIOException e) {
+            if (!causedByTimeout(e)) {
+                throw e;
+            }
+            log.warning("REST request for archive file " + filename + " timed out, reading from local seed");
+        }
+
+        synchronized (this) {
+            try {
+                var seedRepository = repositoryPool.seedRepository(archiveRepository, false);
+                var archiveHash = seedRepository.resolve(archiveRef)
+                                                    .orElseThrow(() -> new IOException("Unknown archive ref: " + archiveRef));
+                return seedRepository.show(Path.of(filename), archiveHash)
+                                     .map(bytes -> new String(bytes, StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/ArchiveWorkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -291,7 +291,7 @@ class ArchiveWorkItem implements WorkItem {
 
         var sentMails = new ArrayList<Email>();
         // Load in already sent emails from the archive, if there are any.
-        var archiveContents = bot.archiveRepo().fileContents(mboxFile(), bot.archiveRef());
+        var archiveContents = bot.archiveFileContents(mboxFile());
         archiveContents.ifPresent(s -> sentMails.addAll(Mbox.splitMbox(s, bot.emailAddress())));
 
         var labels = new HashSet<>(pr.labelNames());

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ public class MailingListBridgeBot implements Bot {
     private final boolean repoInSubject;
     private final Pattern branchInSubject;
     private final Path seedStorage;
+    private final ArchiveFileReader archiveFileReader;
     private final PullRequestPoller poller;
     private final MailingListServer mailingListServer;
 
@@ -68,7 +69,7 @@ public class MailingListBridgeBot implements Bot {
                          boolean webrevGenerateHTML, boolean webrevGenerateJSON, Set<String> readyLabels,
                          Map<String, Pattern> readyComments, URI issueTracker, Map<String, String> headers,
                          Duration cooldown, boolean repoInSubject, Pattern branchInSubject,
-                         Path seedStorage, MailingListServer mailingListServer) {
+                         Path seedStorage, ArchiveFileReader archiveFileReader, MailingListServer mailingListServer) {
         emailAddress = from;
         codeRepo = repo;
         archiveRepo = archive;
@@ -86,6 +87,7 @@ public class MailingListBridgeBot implements Bot {
         this.repoInSubject = repoInSubject;
         this.branchInSubject = branchInSubject;
         this.seedStorage = seedStorage;
+        this.archiveFileReader = archiveFileReader;
         this.mailingListServer = mailingListServer;
 
         webrevStorage = new WebrevStorage(webrevStorageHTMLRepository, webrevStorageJSONRepository, webrevStorageRef,
@@ -108,6 +110,13 @@ public class MailingListBridgeBot implements Bot {
 
     String archiveRef() {
         return archiveRef;
+    }
+
+    Optional<String> archiveFileContents(String filename) {
+        if (archiveFileReader == null) {
+            return archiveRepo.fileContents(filename, archiveRef);
+        }
+        return archiveFileReader.fileContents(filename);
     }
 
     HostedRepository censusRepo() {

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,7 @@ public class MailingListBridgeBotBuilder {
     private boolean repoInSubject = false;
     private Pattern branchInSubject = Pattern.compile("a^"); // Does not match anything
     private Path seedStorage = null;
+    private ArchiveFileReader archiveFileReader = null;
     private MailingListServer mailingListServer;
 
     MailingListBridgeBotBuilder() {
@@ -184,17 +185,27 @@ public class MailingListBridgeBotBuilder {
         return this;
     }
 
+    MailingListBridgeBotBuilder archiveFileReader(ArchiveFileReader archiveFileReader) {
+        this.archiveFileReader = archiveFileReader;
+        return this;
+    }
+
     public MailingListBridgeBotBuilder mailingListServer(MailingListServer mailingListServer) {
         this.mailingListServer = mailingListServer;
         return this;
     }
 
     public MailingListBridgeBot build() {
+        var effectiveArchiveFileReader = archiveFileReader;
+        if (effectiveArchiveFileReader == null && seedStorage != null) {
+            effectiveArchiveFileReader = new ArchiveFileReader(archive, archiveRef, seedStorage);
+        }
         return new MailingListBridgeBot(from, repo, archive, archiveRef, censusRepo, censusRef, lists,
                                         ignoredUsers, ignoredComments,
                                         webrevStorageHTMLRepository, webrevStorageJSONRepository, webrevStorageRef,
                                         webrevStorageBase, webrevStorageBaseUri, webrevGenerateHTML, webrevGenerateJSON,
                                         readyLabels, readyComments, issueTracker, headers,
-                                        cooldown, repoInSubject, branchInSubject, seedStorage, mailingListServer);
+                                        cooldown, repoInSubject, branchInSubject, seedStorage, effectiveArchiveFileReader,
+                                        mailingListServer);
     }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotBuilder.java
@@ -196,16 +196,12 @@ public class MailingListBridgeBotBuilder {
     }
 
     public MailingListBridgeBot build() {
-        var effectiveArchiveFileReader = archiveFileReader;
-        if (effectiveArchiveFileReader == null && seedStorage != null) {
-            effectiveArchiveFileReader = new ArchiveFileReader(archive, archiveRef, seedStorage);
-        }
         return new MailingListBridgeBot(from, repo, archive, archiveRef, censusRepo, censusRef, lists,
                                         ignoredUsers, ignoredComments,
                                         webrevStorageHTMLRepository, webrevStorageJSONRepository, webrevStorageRef,
                                         webrevStorageBase, webrevStorageBaseUri, webrevGenerateHTML, webrevGenerateJSON,
                                         readyLabels, readyComments, issueTracker, headers,
-                                        cooldown, repoInSubject, branchInSubject, seedStorage, effectiveArchiveFileReader,
+                                        cooldown, repoInSubject, branchInSubject, seedStorage, archiveFileReader,
                                         mailingListServer);
     }
 }

--- a/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
+++ b/bots/mlbridge/src/main/java/org/openjdk/skara/bots/mlbridge/MailingListBridgeBotFactory.java
@@ -100,6 +100,8 @@ public class MailingListBridgeBotFactory implements BotFactory {
 
         var archiveRepo = configuration.repository(specific.get("archive").asString());
         var archiveRef = configuration.repositoryRef(specific.get("archive").asString());
+        var seedStorage = configuration.storageFolder().resolve("seeds");
+        var archiveFileReader = new ArchiveFileReader(archiveRepo, archiveRef, seedStorage);
         var globalIssueTracker = URIBuilder.base(specific.get("issues").asString()).build();
 
         var readyLabels = specific.get("ready").get("labels").stream()
@@ -182,7 +184,8 @@ public class MailingListBridgeBotFactory implements BotFactory {
                                                  .issueTracker(issueTracker)
                                                  .headers(headers)
                                                  .cooldown(cooldown)
-                                                 .seedStorage(configuration.storageFolder().resolve("seeds"))
+                                                 .seedStorage(seedStorage)
+                                                 .archiveFileReader(archiveFileReader)
                                                  .mailingListServer(mailmanServer);
 
             if (repoConfig.contains("reponame")) {

--- a/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/ArchiveFileReaderTests.java
+++ b/bots/mlbridge/src/test/java/org/openjdk/skara/bots/mlbridge/ArchiveFileReaderTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.skara.bots.mlbridge;
+
+import org.junit.jupiter.api.*;
+import org.openjdk.skara.forge.HostedRepository;
+import org.openjdk.skara.test.*;
+import org.openjdk.skara.vcs.*;
+
+import java.io.*;
+import java.lang.reflect.*;
+import java.net.http.HttpTimeoutException;
+import java.nio.file.*;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArchiveFileReaderTests {
+    private HostedRepository withFileContentsFailure(HostedRepository repository, IOException failure) {
+        return (HostedRepository) Proxy.newProxyInstance(
+                HostedRepository.class.getClassLoader(),
+                new Class<?>[] { HostedRepository.class },
+                (proxy, method, args) -> {
+                    if (method.getName().equals("fileContents")) {
+                        throw new UncheckedIOException(failure);
+                    }
+                    try {
+                        return method.invoke(repository, args);
+                    } catch (InvocationTargetException e) {
+                        throw e.getCause();
+                    }
+                });
+    }
+
+    @Test
+    void fallbackToSeedAfterTimeout(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var sourceFolder = new TemporaryDirectory();
+             var seedFolder = new TemporaryDirectory()) {
+            var archive = credentials.getHostedRepository();
+            var mboxPath = Path.of("repo", "1.mbox");
+            Files.createDirectories(sourceFolder.path().resolve(mboxPath).getParent());
+            var source = CheckableRepository.init(sourceFolder.path(), archive.repositoryType(), mboxPath,
+                                                  Set.of(), Set.of(), "0.1");
+            var archiveRef = "master";
+            source.push(source.head(), archive.authenticatedUrl(), archiveRef, true);
+
+            var restReader = new ArchiveFileReader(archive, archiveRef, seedFolder.path());
+            assertEquals(Files.readString(sourceFolder.path().resolve(mboxPath)),
+                         restReader.fileContents(mboxPath.toString()).orElseThrow());
+            try (var seedFiles = Files.list(seedFolder.path())) {
+                assertEquals(0, seedFiles.count());
+            }
+
+            var timeoutArchive = withFileContentsFailure(archive, new HttpTimeoutException("request timed out"));
+            var reader = new ArchiveFileReader(timeoutArchive, archiveRef, seedFolder.path());
+
+            assertEquals(Files.readString(sourceFolder.path().resolve(mboxPath)),
+                         reader.fileContents(mboxPath.toString()).orElseThrow());
+
+            CheckableRepository.appendAndCommit(source, "Another archived message");
+            source.push(source.head(), archive.authenticatedUrl(), archiveRef);
+
+            assertEquals(Files.readString(sourceFolder.path().resolve(mboxPath)),
+                         reader.fileContents(mboxPath.toString()).orElseThrow());
+        }
+    }
+
+    @Test
+    void doNotFallbackForOtherIoFailures(TestInfo testInfo) throws IOException {
+        try (var credentials = new HostCredentials(testInfo);
+             var seedFolder = new TemporaryDirectory()) {
+            var archive = credentials.getHostedRepository();
+            var failure = new IOException("not a timeout");
+            var failingArchive = withFileContentsFailure(archive, failure);
+            var reader = new ArchiveFileReader(failingArchive, "master", seedFolder.path());
+
+            var thrown = assertThrows(UncheckedIOException.class, () -> reader.fileContents("repo/1.mbox"));
+            assertSame(failure, thrown.getCause());
+        }
+    }
+}


### PR DESCRIPTION
The mlbridge archive is stored in a large gitlab repository. When an old PR is
 updated, ArchiveWorkItem reads its existing mbox through gitlab’s repository files REST API. For some older archive files, this request consistently exceeds the HTTP timeout, preventing the work item from completing.

When the REST request fails with HttpTimeoutException, mlbridge should fall back to the existing storage-backed repository seed.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2789](https://bugs.openjdk.org/browse/SKARA-2789): Fall back to local seed when reading an archive file times out (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1785/head:pull/1785` \
`$ git checkout pull/1785`

Update a local copy of the PR: \
`$ git checkout pull/1785` \
`$ git pull https://git.openjdk.org/skara.git pull/1785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1785`

View PR using the GUI difftool: \
`$ git pr show -t 1785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1785.diff">https://git.openjdk.org/skara/pull/1785.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1785#issuecomment-5417692941)
</details>
