### PR TITLE
2795: CheckableRepository should apply Repository.ignoreConfiguration()

### DIFF
--- a/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
+++ b/test/src/main/java/org/openjdk/skara/test/CheckableRepository.java
@@ -39,7 +39,7 @@ public class CheckableRepository {
     }
 
     public static Repository init(Path path, VCS vcs, Path appendableFilePath, Set<String> errorChecks, Set<String> warningChecks, String version) throws IOException {
-        var repo = Repository.init(path, vcs);
+        var repo = TestableRepository.init(path, vcs);
 
         Files.createDirectories(path.resolve(".checkable"));
         try (var output = Files.newBufferedWriter(path.resolve(".checkable/name.txt"))) {


### PR DESCRIPTION
To avoid having Git behavior being affected by the local Git configuration, we have Repository.ignoreConfiguration() which sets up the environment for external Git commands. This isn't universally applied however. I just stumbled over a failing test which when run individually, this setup wasn't applied, which caused my local Git configuration to conflict with the test setup.

The test was using CheckableRespository, which is a test support class. I think this test class should call Repository.ignoreConfiguration() so that the likelihood of this being setup is higher in tests. By using TestableRepository.init this setup is handled.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2795](https://bugs.openjdk.org/browse/SKARA-2795): CheckableRepository should apply Repository.ignoreConfiguration() (**Bug** - P4)


### Reviewers
 * [Zhao Song](https://openjdk.org/census#zsong) (@zhaosongzs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1786/head:pull/1786` \
`$ git checkout pull/1786`

Update a local copy of the PR: \
`$ git checkout pull/1786` \
`$ git pull https://git.openjdk.org/skara.git pull/1786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1786`

View PR using the GUI difftool: \
`$ git pr show -t 1786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1786.diff">https://git.openjdk.org/skara/pull/1786.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1786#issuecomment-5501383034)
</details>
