### PR TITLE
2799: Add Host API for searching users

### DIFF
--- a/host/src/main/java/org/openjdk/skara/host/Host.java
+++ b/host/src/main/java/org/openjdk/skara/host/Host.java
@@ -34,7 +34,7 @@ public interface Host {
      * Finds users matching a query, if supported by the host.
      */
     default List<HostUser> searchUsers(String query) {
-        return List.of();
+        throw new UnsupportedOperationException();
     }
 
     HostUser currentUser();

--- a/host/src/main/java/org/openjdk/skara/host/Host.java
+++ b/host/src/main/java/org/openjdk/skara/host/Host.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,20 @@
 package org.openjdk.skara.host;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 public interface Host {
     boolean isValid();
     Optional<HostUser> user(String username);
+
+    /**
+     * Finds users matching a query, if supported by the host.
+     */
+    default List<HostUser> searchUsers(String query) {
+        return List.of();
+    }
+
     HostUser currentUser();
     boolean isMemberOf(String groupId, HostUser user);
     String hostname();

--- a/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
+++ b/issuetracker/src/main/java/org/openjdk/skara/issuetracker/jira/JiraHost.java
@@ -190,6 +190,24 @@ public class JiraHost implements IssueTracker {
     }
 
     @Override
+    public List<HostUser> searchUsers(String query) {
+        var data = request.get("user/search")
+                .param("username", query)
+                .execute();
+
+        return data.stream()
+                .map(JSONValue::asObject)
+                .map(user -> HostUser.builder()
+                        .id(user.get("name").asString())
+                        .username(user.get("name").asString())
+                        .fullName(user.get("displayName").asString())
+                        .email(user.contains("emailAddress") ? user.get("emailAddress").asString() : null)
+                        .active(user.get("active").asBoolean())
+                        .build())
+                .toList();
+    }
+
+    @Override
     public HostUser currentUser() {
         if (currentUser == null) {
             var data = request.get("myself").execute();

--- a/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraIntegrationTests.java
+++ b/issuetracker/src/test/java/org/openjdk/skara/issuetracker/jira/JiraIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,5 +127,21 @@ class JiraIntegrationTests {
         issue = project.issue(issueId).orElseThrow();
         assertTrue(issue.resolution().isPresent());
         assertEquals("Fixed", issue.resolution().get());
+    }
+
+    @Test
+    @EnabledIfTestProperties({"jira.uri", "jira.pat"})
+    void testSearchUsersByEmail() {
+        var currentUser = tracker.currentUser();
+        var email = currentUser.email().orElseThrow();
+        var user = tracker.searchUsers(email).stream()
+                .filter(candidate -> candidate.email().map(email::equalsIgnoreCase).orElse(false))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(currentUser.id(), user.id());
+        assertEquals(currentUser.username(), user.username());
+        assertEquals(currentUser.fullName(), user.fullName());
+        assertEquals(currentUser.email(), user.email());
+        assertEquals(currentUser.active(), user.active());
     }
 }

--- a/test/src/main/java/org/openjdk/skara/test/TestHost.java
+++ b/test/src/main/java/org/openjdk/skara/test/TestHost.java
@@ -288,6 +288,18 @@ public class TestHost implements Forge, IssueTracker {
     }
 
     @Override
+    public List<HostUser> searchUsers(String query) {
+        var normalizedQuery = query.toLowerCase(Locale.ROOT);
+        return data.users.stream()
+                .filter(user -> user.username().toLowerCase(Locale.ROOT).contains(normalizedQuery) ||
+                        user.fullName().toLowerCase(Locale.ROOT).contains(normalizedQuery) ||
+                        user.email().map(email -> email.toLowerCase(Locale.ROOT)
+                                        .contains(normalizedQuery))
+                                .orElse(false))
+                .toList();
+    }
+
+    @Override
     public HostUser currentUser() {
         return data.users.get(currentUser);
     }


### PR DESCRIPTION
Host currently supports looking up a user by username through user(String), but some consumers need to find users using other attributes, such as an email address.

Add Host.searchUsers(String query), returning a list of matching users. Provide a default implementation that returns an empty list for hosts that do not support user search.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace

### Issue
 * [SKARA-2799](https://bugs.openjdk.org/browse/SKARA-2799): Add Host API for searching users (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/skara.git pull/1787/head:pull/1787` \
`$ git checkout pull/1787`

Update a local copy of the PR: \
`$ git checkout pull/1787` \
`$ git pull https://git.openjdk.org/skara.git pull/1787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1787`

View PR using the GUI difftool: \
`$ git pr show -t 1787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/skara/pull/1787.diff">https://git.openjdk.org/skara/pull/1787.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/skara/pull/1787#issuecomment-5592721510)
</details>
